### PR TITLE
Improve ConfigSourceTest.TableTypes

### DIFF
--- a/tea/table/ut/config_test.cpp
+++ b/tea/table/ut/config_test.cpp
@@ -108,7 +108,7 @@ TEST_F(ConfigSourceTest, TableTypes) {
   TableConfig config;
 
   config = ConfigSource::GetTableConfig("tea://special://empty");
-  EXPECT_THAT(config.source, testing::VariantWith<EmptyTable>(EmptyTable()));
+  EXPECT_TRUE(std::holds_alternative<EmptyTable>(config.source));
 
   config = ConfigSource::GetTableConfig("tea://file:///root/subdir/file");
   EXPECT_THAT(config.source, testing::VariantWith<FileTable>(FileTable{"file:///root/subdir/file"}));


### PR DESCRIPTION
`EXPECT_THAT(..., testing::VariantWith<SomeEmptyStruct>)` triggers `-Werror=uninitialized`

```
[581/659] Building CXX object tea/table/CMakeFiles/table_test.dir/ut/config_test.cpp.o
FAILED: [code=1] tea/table/CMakeFiles/table_test.dir/ut/config_test.cpp.o 
/usr/bin/g++-13 -DCARES_STATICLIB -DSNAPPY_CODEC_AVAILABLE -DTEA_BUILD_FDW -DTEA_VERSION=\"1.0\" -DUSE_REST -I/home/runner/work/tea/tea -I/home/runner/local/gpdb/include/postgresql/server -I/home/runner/work/tea/tea/build -I/home/runner/work/tea/tea/build/_deps/rapidjson-src/include -I/home/runner/work/tea/tea/build/_deps/cpr-src/include -I/home/runner/work/tea/tea/build/_deps/smhasher-src/src -I/home/runner/work/tea/tea/build/_deps/hiredis-src -I"/home/runner/work/tea/tea/build /home/runner/work/tea/tea/teapot" -isystem /home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include -isystem /home/runner/work/tea/tea/build/_deps/googletest-src/googletest -isystem /home/runner/work/tea/tea/build/_deps/googletest-src/googlemock/include -isystem /home/runner/work/tea/tea/build/_deps/googletest-src/googlemock -isystem /home/runner/local/include -isystem /home/runner/work/tea/tea/build/_deps/iceberg-cxx-src -isystem /home/runner/work/tea/tea/build/_deps/croaring-src -isystem /home/runner/work/tea/tea/build/_deps/avro-build/include -isystem /home/runner/work/tea/tea/build/_deps/avro-src/lang/c++/include/avro -isystem /home/runner/work/tea/tea/build/_deps/hive-metastore-src -isystem /home/runner/work/tea/tea/build/_deps/thrift-src/lib/cpp/src -isystem /home/runner/work/tea/tea/build/_deps/thrift-build/thrift/lib/cpp/src -isystem /home/runner/work/tea/tea/build/_deps/boost-src -isystem /home/runner/work/tea/tea/build/_deps/curl-src/include -isystem /home/runner/work/tea/tea/build/_deps/curl-src/lib -isystem /home/runner/work/tea/tea/build/_deps/curl-src/. -isystem /usr/lib/llvm-15/include -fno-omit-frame-pointer -pipe -Werror -Wall -Wextra -Wshadow -Wunreachable-code -Wpointer-arith     -Wno-error=mismatched-tags     -Wno-error=sign-compare     -Wno-error=unused-function     -Wno-error=unknown-pragmas     -Wno-error=maybe-uninitialized     -Wno-error=shift-negative-value     -Wno-error=clobbered -Wno-ignored-attributes -Wno-unused-parameter -Wno-missing-field-initializers     -Wno-shadow -Wno-register -O2 -g -DNDEBUG -std=c++20 -fPIE -MD -MT tea/table/CMakeFiles/table_test.dir/ut/config_test.cpp.o -MF tea/table/CMakeFiles/table_test.dir/ut/config_test.cpp.o.d -o tea/table/CMakeFiles/table_test.dir/ut/config_test.cpp.o -c /home/runner/work/tea/tea/tea/table/ut/config_test.cpp
In file included from /home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/internal/gtest-death-test-internal.h:39,
                 from /home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/gtest-death-test.h:41,
                 from /home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/gtest.h:64,
                 from /home/runner/work/tea/tea/build/_deps/googletest-src/googlemock/include/gmock/internal/gmock-internal-utils.h:47,
                 from /home/runner/work/tea/tea/build/_deps/googletest-src/googlemock/include/gmock/gmock-actions.h:145,
                 from /home/runner/work/tea/tea/build/_deps/googletest-src/googlemock/include/gmock/gmock.h:59,
                 from /home/runner/work/tea/tea/tea/table/ut/config_test.cpp:9:
In member function ‘testing::internal::MatcherBase<T>& testing::internal::MatcherBase<T>::operator=(testing::internal::MatcherBase<T>&&) [with T = const tea::EmptyTable&]’,
    inlined from ‘testing::internal::MatcherBase<T>& testing::internal::MatcherBase<T>::operator=(testing::internal::MatcherBase<T>&&) [with T = const tea::EmptyTable&]’ at /home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:320:16,
    inlined from ‘testing::Matcher<const tea::EmptyTable&>& testing::Matcher<const tea::EmptyTable&>::operator=(testing::Matcher<const tea::EmptyTable&>&&)’ at /home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:479:7,
    inlined from ‘testing::Matcher<T>::Matcher(T) [with T = const tea::EmptyTable&]’ at /home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:880:38,
    inlined from ‘virtual void tea::{anonymous}::ConfigSourceTest_TableTypes_Test::TestBody()’ at /home/runner/work/tea/tea/tea/table/ut/config_test.cpp:111:3:
/home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:324:5: error: ‘<unnamed>.testing::Matcher<const tea::EmptyTable&>::<unnamed>.testing::internal::MatcherBase<const tea::EmptyTable&>::buffer_’ is used uninitialized [-Werror=uninitialized]
  324 |     buffer_ = other.buffer_;
      |     ^~~~~~~
/home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h: In member function ‘virtual void tea::{anonymous}::ConfigSourceTest_TableTypes_Test::TestBody()’:
/home/runner/work/tea/tea/build/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:880:38: note: ‘<anonymous>’ declared here
  880 | Matcher<T>::Matcher(T value) { *this = Eq(value); }
      |                                ~~~~~~^~~~~~~~~~~
cc1plus: all warnings being treated as errors
```