### PR TITLE
Read Iceberg without catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,11 @@ Tea adopts [PXF](https://github.com/greenplum-db/pxf-archive) logic to standard 
 
 ## Restrictions
 
-Greenplum 5 is based on PostgreSQL that has no `FOREIGN TABLE` support so you can use Tea with `EXTERNAL TABLE` only for them.
 Greenplum 6 has restricted support of `FOREIGN TABLE`. Especially you cannot use [GP Orca](https://www.vmware.com/docs/white-paper-orca-a-modular-query-optimizer-architecture-for-big-data) with them.
-`EXTERNAL TABLE` has no separate qusery coordinator. Such tables require special tasks-coordination logic enabled in config (we call it `samovar`) and separate Redis or Valkey installation its work.
-`Samovar` is also used for work-stealing between Greenplum segments.
 
-## Install
+## Setup
 
-Extract Tea from tea-{platform}-{version}.tar.gz into Greenplum home directory.
-```
-export GPHOME=/path/to/greenplum
-tar xzf tea-linux-1.70.0.tar.gz --strip-components=1 -C $GPHOME
-```
-
-Edit $GPHOME/tea/tea-config.json. At least you have to set access and secret keys to object storage and address for Iceberg catalog.
+Edit $GPHOME/tea/tea-config.json. At least you have to set access and secret keys to object storage
 ```
 {
     "common": {
@@ -33,11 +24,6 @@ Edit $GPHOME/tea/tea-config.json. At least you have to set access and secret key
             "secret_key": "minioadmin",
             "endpoint_override": "127.0.0.1:9000",
             "scheme": "http"
-        },
-        "catalog": {
-            "type" : "hms",
-            "hms": "127.0.0.1:9083",
-            "rest": "127.0.0.1:19120"
         }
     }
 }
@@ -47,30 +33,19 @@ More configuration fields you can find in [tea-config.json](test/config/tea-conf
 
 ## How to use
 
-To access data from Apache Iceberg you should register `tea` extention and create `EXTERNAL TABLE` or `FOREIGN TABLE` to every Iceberg table you want to read.
-
-#### External tables
-
-```
-CREATE EXTENSION tea;
-
-CREATE READABLE EXTERNAL TABLE table_name (...)
-LOCATION ('tea://iceberg_namespace.iceberg_table')
-FORMAT 'custom' (formatter = tea_import);
-```
-It creates an `EXTERNAL TABLE` linked to an Iceberg table `iceberg_namespace.iceberg_table` declared in Iceberg catalog.
-Created table is accessible for reading.
+To access data from Apache Iceberg you should register `tea` extention and create `FOREIGN TABLE` to every Iceberg table you want to read.
 
 #### FDW
 ```
-CREATE EXTENSION tea;
-CREATE SERVER tea_server FOREIGN DATA WRAPPER tea_fdw;
+CREATE EXTENSION tea WITH VERSION '1.78.0';
+CREATE FOREIGN DATA WRAPPER tea_fdw HANDLER tea_fdw_handler VALIDATOR tea_fdw_validator;
+CREATE SERVER tea_server FOREIGN DATA WRAPPER tea_fdw OPTIONS (mpp_execute 'all segments');
 
 CREATE FOREIGN TABLE table_name (...)
 SERVER tea_server
-OPTIONS(location 'tea://iceberg_namespace.iceberg_table');
+OPTIONS(location 'tea://icebergs3://s3:// ... .metadata.json');
 ```
-It creates a `FOREIGN TABLE` linked to an Iceberg table `iceberg_namespace.iceberg_table` declared in Iceberg catalog.
+It creates a `FOREIGN TABLE` linked to an Iceberg table described in JSON from S3.
 Created table is accessible for reading.
 
 ## Update Tea

--- a/tea/common/config.cpp
+++ b/tea/common/config.cpp
@@ -664,6 +664,9 @@ TableConfig ConfigSource::GetTableConfig(std::string_view url, const std::string
     table_config.source = TeapotTable{.table_id = TableId::FromString(table_id)};
   } else if (schema == "iceberg") {
     table_config.source = IcebergTable{TableId::FromString(components.location)};
+  } else if (schema == "icebergs3") {
+    table_config.source =
+        IcebergS3{.url = std::string(nested_url, 12, nested_url.size() - 12)}; /* strlen("icebergs3://") = 12 */
   } else if (schema == "special" && components.location == "empty") {
     table_config.source = EmptyTable{};
   } else if (schema == "special" && components.location == "iceberg_tables_metrics") {

--- a/tea/common/config.h
+++ b/tea/common/config.h
@@ -239,6 +239,12 @@ struct IcebergTable {
   auto operator<=>(const IcebergTable&) const = default;
 };
 
+struct IcebergS3 {
+  std::string url;
+
+  auto operator<=>(const IcebergS3&) const = default;
+};
+
 struct FileTable {
   std::string url;
 
@@ -253,9 +259,9 @@ struct IcebergMetricsTable {
   auto operator<=>(const IcebergMetricsTable&) const = default;
 };
 
-enum TableType { kEmpty, kTeapot, kIceberg, kFile, kTotalMetrics };
+enum TableType { kEmpty, kTeapot, kIceberg, kIcebergS3, kFile, kTotalMetrics };
 // TODO(hvintus): replace with proper interface
-using TableSource = std::variant<EmptyTable, TeapotTable, IcebergTable, FileTable, IcebergMetricsTable>;
+using TableSource = std::variant<EmptyTable, TeapotTable, IcebergTable, IcebergS3, FileTable, IcebergMetricsTable>;
 
 struct TableConfig {
   TableSource source;

--- a/tea/gpext/tea_reader.cpp
+++ b/tea/gpext/tea_reader.cpp
@@ -559,6 +559,8 @@ void TeaContextInitialize(int db_encoding) {
 static tea::TableType TableTypeFromSource(const tea::TableSource& source) {
   if (std::holds_alternative<tea::IcebergTable>(source)) {
     return tea::TableType::kIceberg;
+  } else if (std::holds_alternative<tea::IcebergS3>(source)) {
+    return tea::TableType::kIcebergS3;
   } else if (std::holds_alternative<tea::TeapotTable>(source)) {
     return tea::TableType::kTeapot;
   } else if (std::holds_alternative<tea::FileTable>(source)) {
@@ -642,10 +644,19 @@ static iceberg::ice_tea::ScanMetadata GetMetaFromIceberg(TeaContextPtr tea_ctx, 
                                                          const std::string& extracted_filter,
                                                          const tea::CancelToken& cancel_token) {
   auto filter = iceberg::filter::StringToFilter(extracted_filter);
-  auto res_with_stats = tea::meta::access::FromIceberg(
-      table_config.config, std::get<tea::IcebergTable>(table_config.source).table_id, filter,
-      get::FileSystemProvider(tea_ctx), tea::TimestampToTimestamptzShiftUs(),
-      table_config.config.features.use_iceberg_metadata_partition_pruning ? filter : nullptr, cancel_token);
+  auto res_with_stats =
+      TableTypeFromSource(get::Source(tea_ctx)) == tea::TableType::kIceberg
+          ? tea::meta::access::FromIceberg(
+                table_config.config, std::get<tea::IcebergTable>(table_config.source).table_id, filter,
+                get::FileSystemProvider(tea_ctx), tea::TimestampToTimestamptzShiftUs(),
+                table_config.config.features.use_iceberg_metadata_partition_pruning ? filter : nullptr, cancel_token)
+          : tea::meta::access::FromIcebergWithLocation(
+                filter, get::FileSystemProvider(tea_ctx), std::get<tea::IcebergS3>(table_config.source).url,
+                tea::TimestampToTimestamptzShiftUs(),
+                [&](const iceberg::Schema& schema) {
+                  return schema.Columns().size() >= table_config.config.features.use_avro_projection_minimum_columns;
+                },
+                table_config.config.features.use_iceberg_metadata_partition_pruning ? filter : nullptr, cancel_token);
   get::PlannerStats(tea_ctx).Combine(res_with_stats.second);
   return std::move(res_with_stats.first);
 }
@@ -678,11 +689,13 @@ static iceberg::ice_tea::ScanMetadata GetMetadataForSegment(TeaContextPtr tea_ct
 static iceberg::ice_tea::ScanMetadata GetAllMetadata(TeaContextPtr tea_ctx, const tea::TableConfig& table_config,
                                                      const std::string& session_id, const std::string& extracted_filter,
                                                      const tea::CancelToken& cancel_token) {
-  auto access_type = TableTypeFromSource(get::Source(tea_ctx));
-  if (access_type == tea::TableType::kIceberg) {
-    return GetMetaFromIceberg(tea_ctx, table_config, extracted_filter, cancel_token);
+  switch (TableTypeFromSource(get::Source(tea_ctx))) {
+    case tea::TableType::kIceberg:
+    case tea::TableType::kIcebergS3:
+      return GetMetaFromIceberg(tea_ctx, table_config, extracted_filter, cancel_token);
+    default:
+      return GetMetadataForSegment(tea_ctx, table_config, 0, 1, session_id, extracted_filter);
   }
-  return GetMetadataForSegment(tea_ctx, table_config, 0, 1, session_id, extracted_filter);
 }
 
 using ResultType = arrow::Result<std::pair<tea::meta::PlannedMeta, tea::PlannerStats>>;


### PR DESCRIPTION
Add a new scheme (icebergs3) to use S3 url of JSON file, which contains Iceberg
metadata, in the location property of a foreign table.
Rewrite README.md to make it match the code. Describe icebergs3 as a standard
use case. Remove mentions about external tables, because we plan to use foreign
tables only and external tables have not yet been tested.