### PR TITLE
Fix table_test building when GPDB is configured with --enable-cassert

### DIFF
--- a/tea/table/ut/bridge_test.cpp
+++ b/tea/table/ut/bridge_test.cpp
@@ -13,6 +13,18 @@ extern "C" {
 #include "mb/pg_wchar.h"
 }
 
+#ifdef USE_ASSERT_CHECKING
+bool assert_enabled = true;
+
+void ExceptionalCondition(const char* conditionName, const char* errorType, const char* fileName, int lineNumber) {
+  std::cerr << "conditionName = " << conditionName << '\n'
+            << "errorType = " << errorType << '\n'
+            << "fileName = " << fileName << '\n'
+            << "lineNumber = " << lineNumber << '\n';
+  abort();
+}
+#endif
+
 namespace tea {
 namespace {
 


### PR DESCRIPTION
When GPDB is configured with --enable-cassert, USE_ASSERT_CHECKING is defined.
In this case the VARSIZE_ANY_EXHDR macro is replaced with a statement which
uses assert_enabled and calls ExceptionalCondition. These variable and function
are defined in GPDB core, so table_test linking failed.
Define assert_enabled and ExceptionalCondition in the test code when
USE_ASSERT_CHECKING is defined.