### PR TITLE
Set TEA_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(tea)
 # Base versions of Tea to generate upgrade and downgrade scripts
 set(TEA_BASE_VERSIONS 1.71.2 1.72.2 1.72.3 1.73.0 1.74.0 1.74.1 1.75.0 1.76.0 1.76.1 1.76.2 1.76.3 1.77.0 1.77.1 1.77.2 1.78.0)
 set(TEA_BASE_VERSIONS_WO_ICE_UDF 1.63.0 1.63.1 1.63.2 1.63.3 1.63.4 1.63.5 1.63.6 1.64.0 1.64.1 1.65.0 1.65.1 1.66.0 1.67.0 1.68.0 1.69.0 1.70.0)
+set(TEA_VERSION 1.79.0)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
It was necessary to pass TEA_VERSION to cmake. Now the version is set by default.