### PR TITLE
Rename REST to Nessie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install -y \
             bison \
             cmake \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 option(TEA_BUILD_FDW "Build Foreign Data Wrapper" ON)
 option(HAS_ARROW_CSV "Arrow built with csv" ON)
 option(ICECXX_GENERATOR "" ON)
-option(USE_REST "Enable Rest catalog" ON)
+option(USE_NESSIE "Enable Nessie catalog" ON)
 option(TEA_USE_THREAD_SANITIZER "Enable running tests with ThreadSanitizer" ON)
 
 cmake_minimum_required(VERSION 3.25)
@@ -55,8 +55,8 @@ if(TEA_BUILD_FDW)
   add_compile_definitions(TEA_BUILD_FDW)
 endif()
 
-if(USE_REST)
-  add_compile_definitions(USE_REST)
+if(USE_NESSIE)
+  add_compile_definitions(USE_NESSIE)
 endif()
 
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Edit $GPHOME/tea/tea-config.json. At least you have to set access and secret key
         "catalog": {
             "type" : "hms",
             "hms": "127.0.0.1:9083",
-            "rest": "127.0.0.1:19120"
+            "nessie": "127.0.0.1:19120"
         }
     }
 }

--- a/tea/common/config.cpp
+++ b/tea/common/config.cpp
@@ -248,8 +248,8 @@ bool Get(const rapidjson::Value* doc, std::string_view section_prefix, std::stri
   if (str.empty() || str == "hms") {
     *out = CatalogConfig::CatalogType::kHMS;
     return true;
-  } else if (str == "rest") {
-    *out = CatalogConfig::CatalogType::kREST;
+  } else if (str == "nessie") {
+    *out = CatalogConfig::CatalogType::kNessie;
     return true;
   }
   return false;
@@ -375,7 +375,7 @@ arrow::Status ReadValues(Source* src, Config* config, std::string_view section_p
 
   Get(src, section_prefix, "catalog", "type", &config->catalog.type);
   GetEndpoints(src, section_prefix, "catalog", "hms", &config->catalog.hms_endpoints);
-  GetEndpoints(src, section_prefix, "catalog", "rest", &config->catalog.rest_endpoints);
+  GetEndpoints(src, section_prefix, "catalog", "nessie", &config->catalog.nessie_endpoints);
 
   GetEndpoints(src, section_prefix, "hms", "hms", &config->hms_catalog.hms_endpoints);
 

--- a/tea/common/config.h
+++ b/tea/common/config.h
@@ -40,12 +40,12 @@ struct Endpoint {
 
 struct CatalogConfig {
   enum class CatalogType {
-    kREST,
+    kNessie,
     kHMS,
   } type = CatalogType::kHMS;
 
   std::vector<Endpoint> hms_endpoints;
-  std::vector<Endpoint> rest_endpoints;
+  std::vector<Endpoint> nessie_endpoints;
 
   bool operator==(const CatalogConfig&) const = default;
 };

--- a/tea/common/file_reader_provider.cpp
+++ b/tea/common/file_reader_provider.cpp
@@ -68,7 +68,7 @@ uint64_t CalculateBatchSizeFile(const FileReaderProviderWithProperties::Adaptive
 
 }  // namespace
 
-arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> FileReaderProviderWithProperties::Open(
+arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> FileReaderProviderWithProperties::OpenParquet(
     const std::string& url) const {
   ARROW_ASSIGN_OR_RAISE(auto fs, fs_provider_->GetFileSystem(url));
   ARROW_ASSIGN_OR_RAISE(auto path, GetPath(url));
@@ -97,11 +97,11 @@ arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> FileReaderProviderWit
   return arrow_reader;
 }
 
-arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> CachingFileReaderProvider::Open(
+arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> CachingFileReaderProvider::OpenParquet(
     const std::string& url) const {
   try {
     return metadata_cache_.GetValueOrCalculate(url, [provider = provider_, &url]() {
-      auto maybe_arrow_reader = provider->Open(url);
+      auto maybe_arrow_reader = provider->OpenParquet(url);
       if (!maybe_arrow_reader.ok()) {
         throw maybe_arrow_reader.status();
       }

--- a/tea/common/file_reader_provider.h
+++ b/tea/common/file_reader_provider.h
@@ -33,7 +33,11 @@ class FileReaderProviderWithProperties : public iceberg::IFileReaderProvider {
         field_ids_to_retrieve_(field_ids_to_retrieve.begin(), field_ids_to_retrieve.end()),
         adaptive_batch_info_(adaptive_batch_info) {}
 
-  arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> Open(const std::string& url) const override;
+  arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> OpenParquet(const std::string& url) const override;
+  arrow::Result<std::shared_ptr<iceberg::DeletionVector>> OpenDeletionVector(const std::string& path, int64_t offset,
+                                                                             int64_t length) const override {
+    return arrow::Status::NotImplemented("OpenDeletionVector is not implemented");
+  }
 
  private:
   ReaderProperties properties_;
@@ -47,7 +51,11 @@ class CachingFileReaderProvider : public iceberg::IFileReaderProvider {
   CachingFileReaderProvider(std::shared_ptr<const iceberg::IFileReaderProvider> provider, size_t cache_size)
       : provider_(provider), metadata_cache_(cache_size) {}
 
-  arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> Open(const std::string& url) const override;
+  arrow::Result<std::shared_ptr<parquet::arrow::FileReader>> OpenParquet(const std::string& url) const override;
+  arrow::Result<std::shared_ptr<iceberg::DeletionVector>> OpenDeletionVector(const std::string& path, int64_t offset,
+                                                                             int64_t length) const override {
+    return arrow::Status::NotImplemented("OpenDeletionVector is not implemented");
+  }
 
  private:
   using MetadataCacheValue = std::shared_ptr<parquet::arrow::FileReader>;

--- a/tea/gpext/CMakeLists.txt
+++ b/tea/gpext/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(
   tea PRIVATE reader tea_log teapot_file_filter Arrow::arrow_static
               Parquet::parquet_static teapot_grpc_proto gp_filter_convert)
 
-if (USE_REST)
+if (USE_NESSIE)
   target_link_libraries(tea PRIVATE cpr)
 endif()
 

--- a/tea/metadata/access_file.cpp
+++ b/tea/metadata/access_file.cpp
@@ -138,8 +138,8 @@ iceberg::ice_tea::ScanMetadata FromFileUrl(const std::string& file_url,
   iceberg::ice_tea::ScanMetadata meta;
 
   meta.schema = [&]() {
-    iceberg::FileReaderProvider file_reader_provider(fs_provider);
-    auto file_reader = iceberg::ValueSafe(file_reader_provider.Open(file_url));
+    auto file_reader_provider = MakeFileReaderProvider(fs_provider);
+    auto file_reader = iceberg::ValueSafe(file_reader_provider->OpenParquet(file_url));
     iceberg::Ensure(file_reader.get(), std::string(__PRETTY_FUNCTION__) + ": file_reader is nullptr");
 
     auto parquet_reader = file_reader->parquet_reader();

--- a/tea/metadata/access_iceberg.cpp
+++ b/tea/metadata/access_iceberg.cpp
@@ -19,7 +19,7 @@
 #include "iceberg/filter/stats_filter/stats_filter.h"
 #include "iceberg/schema.h"
 #include "iceberg/tea_hive_catalog.h"
-#include "iceberg/tea_rest_catalog.h"
+#include "iceberg/tea_nessie_catalog.h"
 #include "iceberg/tea_scan.h"
 
 #include "tea/common/cancel.h"
@@ -60,17 +60,17 @@ std::shared_ptr<iceberg::ice_tea::RemoteCatalog> GetCatalog(const Config& config
       throw std::runtime_error("No correct HMS endpoints for iceberg catalog were provided " +
                                std::to_string(config.catalog.hms_endpoints.size()));
     }
-    case CatalogConfig::CatalogType::kREST: {
-#if USE_REST
-      for (const auto& [host, port] : config.catalog.rest_endpoints) {
+    case CatalogConfig::CatalogType::kNessie: {
+#if USE_NESSIE
+      for (const auto& [host, port] : config.catalog.nessie_endpoints) {
         try {
-          return std::make_shared<iceberg::ice_tea::RESTCatalog>(host, port);
+          return std::make_shared<iceberg::ice_tea::NessieCatalog>(host, port);
         } catch (...) {
-          TEA_LOG("Failed to connect to REST catalog (" + host + ":" + std::to_string(port) + ")");
+          TEA_LOG("Failed to connect to Nessie catalog (" + host + ":" + std::to_string(port) + ")");
         }
       }
 #endif
-      throw std::runtime_error("No correct REST endpoints for iceberg catalog were provided");
+      throw std::runtime_error("No correct Nessie endpoints for iceberg catalog were provided");
     }
   }
   throw std::runtime_error("No any correct endpoint for iceberg catalog were provided");

--- a/tea/metadata/estimator.cpp
+++ b/tea/metadata/estimator.cpp
@@ -272,7 +272,7 @@ arrow::Result<RelationSize> Estimator::GetRelationSizeFromDataFiles(
                                                                                  std::vector<int32_t>{}, std::nullopt);
 
   ForEachPlannedDataEntry(metadata, [&rows, file_reader_provider](const iceberg::ice_tea::DataEntry& entry) {
-    auto maybe_arrow_reader = file_reader_provider->Open(entry.path);
+    auto maybe_arrow_reader = file_reader_provider->OpenParquet(entry.path);
     if (!maybe_arrow_reader.ok()) {
       throw maybe_arrow_reader.status();
     }

--- a/tea/test_utils/nessie_utils.cpp
+++ b/tea/test_utils/nessie_utils.cpp
@@ -85,7 +85,7 @@ if __name__ == "__main__":
 
 void UploadNessieCatalog([[maybe_unused]] const std::string& db_name, [[maybe_unused]] const std::string& table_name,
                          [[maybe_unused]] const std::string& location) {
-#if USE_REST
+#if USE_NESSIE
   std::ofstream file("script.py");
   if (!file) {
     throw std::runtime_error("Can not open script file");

--- a/test/config/tea-config-schema.json
+++ b/test/config/tea-config-schema.json
@@ -16,11 +16,11 @@
         "catalog": {
             "type": "object",
             "properties": {
-                "type": { "type": "string", "enum": ["hms", "rest"] },
+                "type": { "type": "string", "enum": ["hms", "nessie"] },
                 "hms": { "type": "string" },
-                "rest": { "type": "string" }
+                "nessie": { "type": "string" }
             },
-            "required": ["type", "hms", "rest"]
+            "required": ["type", "hms", "nessie"]
         },
         "teapot": {
             "type": "object",

--- a/test/config/tea-config.json
+++ b/test/config/tea-config.json
@@ -13,7 +13,7 @@
         "catalog": {
             "type": "hms",
             "hms": "iamincorrecthost:9090,127.0.0.1:9090",
-            "rest": "127.0.0.1:19120"
+            "nessie": "127.0.0.1:19120"
         },
         "teapot": {
             "location": "localhost:50002",
@@ -167,8 +167,8 @@
         },
         "nessie": {
             "catalog": {
-                "type": "rest",
-                "rest": "127.0.0.1:19120"
+                "type": "nessie",
+                "nessie": "127.0.0.1:19120"
             }
         },
         "broken_hms": {

--- a/test/config/tea.cfg
+++ b/test/config/tea.cfg
@@ -9,7 +9,7 @@ request_timeout_ms=3000
 [catalog]
 type=hms
 hms=iamincorrecthost:9090,127.0.0.1:9090
-rest=127.0.0.1:19120
+nessie=127.0.0.1:19120
 
 [teapot]
 location=localhost:50002
@@ -119,8 +119,8 @@ wait_before_processing=true
 time_before_processing_ms=10000
 
 [profiles.nessie.catalog]
-type=rest
-rest=127.0.0.1:19120
+type=nessie
+nessie=127.0.0.1:19120
 
 [profiles.broken_hms.catalog]
 type=hms

--- a/vendor/CMakeLists.txt
+++ b/vendor/CMakeLists.txt
@@ -30,7 +30,7 @@ FetchContent_Declare(
   iceberg-cxx
   EXCLUDE_FROM_ALL
   GIT_REPOSITORY ${GITHUB}/lithium-tech/iceberg-cxx.git
-  GIT_TAG 9b87fbd2aa78d322f971b81243b70310e03dbffc
+  GIT_TAG 237999bd29e6bda22135cce5feda78db62b96eed
 )
 
 FetchContent_MakeAvailable(googletest hiredis)
@@ -39,5 +39,5 @@ set(ICECXX_BUILD_ARROW OFF CACHE BOOL "")
 set(ICECXX_BUILD_ABSEIL OFF CACHE BOOL "")
 set(ICECXX_BUILD_TOOLS ON CACHE BOOL "")
 set(ICECXX_GENERATOR ${ICECXX_GENERATOR} CACHE BOOL "")
-set(ICECXX_USE_REST ${USE_REST} CACHE BOOL "")
+set(ICECXX_USE_NESSIE ${USE_NESSIE} CACHE BOOL "")
 FetchContent_MakeAvailable(iceberg-cxx)


### PR DESCRIPTION
TEA can interact with Nessie, but REST is another protocol which is not
supported now. The renaming is needed to avoid misleading users.

To make the renaming it is necessary to bump iceberg-cxx to the version where
the same renaming has already been done.
The new iceberg-cxx version has extra changes in its API:
- The Open method in the iceberg::IFileReaderProvider class has been renamed to
OpenParquet. So we need to rename Open to OpenParquet in the derived classes
too.
- The OpenDeletionVector pure virtual function has been added to
iceberg::IFileReaderProvider. So we need to add its unusable stub implementation
to the derived classes.