### PR TITLE
Remove redundant packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,38 +221,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            iproute2 \
-            iputils-ping \
-            libapr1-dev \
-            libaprutil1-dev \
-            libbz2-dev \
-            libcurl4-openssl-dev \
-            libevent-dev \
-            libipc-run-perl \
-            libkrb5-dev \
-            libpam-dev \
-            libperl-dev \
-            libreadline-dev \
-            libssl-dev \
-            libtool \
-            libuv1-dev \
-            libxerces-c-dev \
-            libxml2-dev \
-            libxslt-dev \
-            libyaml-dev \
-            libzstd-dev \
-            locales \
-            net-tools \
-            openssh-client \
-            openssh-server \
+            libxerces-c3.2 \
             python2 \
-            python2-dev \
             redis-server \
-            rsync \
-            zlib1g-dev \
             software-properties-common
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get install -y gcc-13 g++-13
+          sudo apt-get install -y libstdc++6
           sudo systemctl disable --now redis-server
           sudo ln -s -f python2 /usr/bin/python
           sudo locale-gen "en_US.UTF-8"


### PR DESCRIPTION
Reduce CI execution time and bandwidth usage by removing unnecessary build-time dependencies from the runtime test environment. This change aligns the installed packages with the minimal runtime requirements for Greenplum and TEA, making the pipeline faster and cleaner without affecting test stability.