### PR TITLE
ci: remove redundant packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,10 +303,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            libevent-2.1-7 \
-            libipc-run-perl \
             libxerces-c3.2 \
-            libxml2 \
             python2 \
             software-properties-common
 


### PR DESCRIPTION
Reduce CI execution time and bandwidth usage by removing unnecessary build-time dependencies from the runtime test environment. This change aligns the installed packages with the minimal runtime requirements for Greenplum and TEA, making the pipeline faster and cleaner without affecting test stability.