### PR TITLE
Remove redundant return statements

### DIFF
--- a/tea/gpext/tea_fdw.c
+++ b/tea/gpext/tea_fdw.c
@@ -376,13 +376,6 @@ static void TeaGetForeignPaths(PlannerInfo* root, RelOptInfo* baserel, Oid forei
                                  NULL, /* no outer rel either */
                                  fpinfo->retrieved_attrs);
   add_path(baserel, (Path*)path);
-
-  /*
-   * If we're not using remote estimates, stop here.  We have no way to
-   * estimate whether any join clauses would be worth sending across, so
-   * don't bother building parameterized paths.
-   */
-  return;
 }
 
 /*
@@ -678,8 +671,6 @@ static void FetchDataToVirtualTuple(TeaScanState* fsstate, MemoryContext tuple_c
   PG_CATCH();
   PG_RE_THROW();
   PG_END_TRY();
-
-  return;
 }
 
 /*


### PR DESCRIPTION
In C, reaching the closing brace `}` of a `void` function implicitly returns control to the caller. Explicit `return;` statements in these positions are unnecessary noise that clutters the code. Removing them aligns the code with common C style guidelines and improves readability.