### PR TITLE
Adding OpenGPDB support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,96 @@
+name: build
+
+# Reusable workflow: build tea against a given Greenplum fork and upload the
+# runtime artifacts. Called by ci.yml once per fork (arenadata + open-gpdb).
+on:
+  workflow_call:
+    inputs:
+      gpdb_repo:
+        description: Git URL of the Greenplum fork to build
+        required: true
+        type: string
+      gpdb_ref:
+        description: Branch or tag of the Greenplum fork
+        required: true
+        type: string
+      cache_key:
+        description: actions/cache key for the installed dependencies (~/local)
+        required: true
+        type: string
+      artifact_name:
+        description: Name of the uploaded runtime artifact
+        required: true
+        type: string
+      open_gpdb:
+        description: Apply the open-gpdb-specific build fixups and checks
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Clear cache
+        run: bash ci/clear-runner-cache.sh
+
+      - name: Install dependencies
+        run: bash ci/install-build-deps.sh
+
+      - name: Prepare directories
+        run: bash ci/prepare-dirs.sh
+
+      - name: Cache installed dependencies
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: ~/local
+          key: ${{ inputs.cache_key }}
+
+      - name: Cache Arrow third-party downloads
+        id: cache-arrow-thirdparty
+        uses: actions/cache@v4
+        with:
+          path: build/arrow-thirdparty
+          key: arrow-thirdparty-15.0.2
+
+      - name: Free disk space
+        if: inputs.open_gpdb
+        run: bash ci/free-disk-space.sh
+
+      - name: Build and install Greenplum
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: bash ci/build-gpdb.sh "${{ inputs.gpdb_repo }}" "${{ inputs.gpdb_ref }}" ${{ inputs.open_gpdb && 'open-gpdb' || '' }}
+
+      - name: Build and install Arrow 15
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: bash ci/build-arrow.sh
+
+      - name: Build and install gRPC
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: bash ci/build-grpc.sh
+
+      - name: Verify open-gpdb defines OPENGPDB
+        if: inputs.open_gpdb
+        run: bash ci/verify-opengpdb-define.sh
+
+      - name: Build Tea
+        run: bash ci/build-tea.sh
+
+      - name: Run unit tests
+        run: |
+          cd build
+          ctest --output-on-failure
+
+      - name: Pack runtime artifacts
+        run: bash ci/pack-artifacts.sh
+
+      - name: Upload runtime artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ci-artifacts
+          retention-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,251 +27,42 @@ jobs:
             | xargs -r clang-format --dry-run -Werror
 
   build-tea-agp:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Clear cache
-        run: bash ci/clear-runner-cache.sh
-
-      - name: Install dependencies
-        run: bash ci/install-build-deps.sh
-
-      - name: Prepare directories
-        run: bash ci/prepare-dirs.sh
-
-      - name: Cache installed dependencies
-        id: cache-deps
-        uses: actions/cache@v4
-        with:
-          path: ~/local
-          key: deps-gp-6.29.1_arenadata68-arrow-15.0.2-grpc-1.62.3-gcc13-${{ runner.os }}-v6
-
-      - name: Cache Arrow third-party downloads
-        id: cache-arrow-thirdparty
-        uses: actions/cache@v4
-        with:
-          path: build/arrow-thirdparty
-          key: arrow-thirdparty-15.0.2
-
-      - name: Build and install Greenplum 6
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: bash ci/build-gpdb.sh https://github.com/arenadata/gpdb.git 6.29.1_arenadata68
-
-      - name: Build and install Arrow 15
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: bash ci/build-arrow.sh
-
-      - name: Build and install gRPC
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: bash ci/build-grpc.sh
-
-      - name: Build Tea
-        run: bash ci/build-tea.sh
-
-      - name: Run unit tests
-        run: |
-          cd build
-          ctest --output-on-failure
-
-      - name: Pack runtime artifacts
-        run: bash ci/pack-artifacts.sh
-
-      - name: Upload runtime artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: tea-runtime
-          path: ci-artifacts
-          retention-days: 1
+    uses: ./.github/workflows/build.yml
+    with:
+      gpdb_repo: https://github.com/arenadata/gpdb.git
+      gpdb_ref: 6.29.1_arenadata68
+      cache_key: deps-gp-6.29.1_arenadata68-arrow-15.0.2-grpc-1.62.3-gcc13-Linux-v6
+      artifact_name: tea-runtime
 
   # Build tea against open-gpdb (instead of arenadata/gpdb) to make sure it
   # keeps compiling/linking there. open-gpdb diverges from other Greenplum
   # forks (e.g. it moved the sampling helpers into utils/sampling.h and
   # removed the legacy anl_* API); tea selects the right API via the OPENGPDB
   # macro that open-gpdb defines in pg_config_manual.h. This job guards that
-  # path. NOTE: it requires the OPENGPDB define to be present in the cloned
-  # open-gpdb branch.
+  # path (open_gpdb: true enables the fork-specific build fixups and checks).
   build-tea-open-gpdb:
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Clear cache
-        run: bash ci/clear-runner-cache.sh
-
-      - name: Install dependencies
-        run: bash ci/install-build-deps.sh
-
-      - name: Prepare directories
-        run: bash ci/prepare-dirs.sh
-
-      - name: Cache installed dependencies
-        id: cache-deps
-        uses: actions/cache@v4
-        with:
-          path: ~/local
-          key: deps-open-gpdb-OPENGPDB_STABLE-arrow-15.0.2-grpc-1.62.3-gcc13-${{ runner.os }}-v4
-
-      - name: Cache Arrow third-party downloads
-        id: cache-arrow-thirdparty
-        uses: actions/cache@v4
-        with:
-          path: build/arrow-thirdparty
-          key: arrow-thirdparty-15.0.2
-
-      - name: Free disk space
-        run: bash ci/free-disk-space.sh
-
-      - name: Build and install open-gpdb
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: bash ci/build-gpdb.sh https://github.com/open-gpdb/gpdb.git OPENGPDB_STABLE open-gpdb
-
-      - name: Build and install Arrow 15
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: bash ci/build-arrow.sh
-
-      - name: Build and install gRPC
-        if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: bash ci/build-grpc.sh
-
-      - name: Verify open-gpdb defines OPENGPDB
-        run: bash ci/verify-opengpdb-define.sh
-
-      - name: Build Tea against open-gpdb
-        run: bash ci/build-tea.sh
-
-      - name: Run unit tests
-        run: |
-          cd build
-          ctest --output-on-failure
-
-      - name: Pack runtime artifacts
-        run: bash ci/pack-artifacts.sh
-
-      - name: Upload runtime artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: tea-runtime-open-gpdb
-          path: ci-artifacts
-          retention-days: 1
-
-  # Run the full tea smoke-test suite (not just ANALYZE) against open-gpdb.
-  # Mirrors the smoke-tests job below, which only covers arenadata/gpdb.
-  # Kept as a separate job (needs only build-tea-open-gpdb) so the arenadata
-  # smoke-tests do not wait on the open-gpdb build.
-  smoke-tests-open-gpdb:
-    needs: build-tea-open-gpdb
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - metadata_type: teapot
-            table_type: foreign
-            profile: ""
-          - metadata_type: teapot
-            table_type: external
-            profile: ""
-          - metadata_type: iceberg
-            table_type: foreign
-            profile: samovar
-          - metadata_type: iceberg
-            table_type: external
-            profile: samovar
-          - metadata_type: iceberg
-            table_type: foreign
-            profile: ""
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install runtime dependencies
-        run: bash ci/install-runtime-deps.sh
-
-      - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: tea-runtime-open-gpdb
-          path: ci-artifacts
-
-      - name: Restore runtime files
-        run: bash ci/restore-runtime.sh
-
-      - name: Initialize Greenplum cluster
-        run: bash ci/start-cluster.sh --create-extension
-
-      - name: Start Iceberg services (Minio + HMS) and upload test data
-        run: bash ci/start-iceberg.sh
-
-      - name: Deploy tea config
-        run: bash ci/deploy-tea-config.sh
-
-      - name: Start Redis
-        run: |
-          sudo systemctl start redis-server
-          redis-cli ping
-
-      - name: Run smoke tests
-        run: bash ci/run-smoke.sh "${{ matrix.metadata_type }}" "${{ matrix.table_type }}" "${{ matrix.profile }}"
+    uses: ./.github/workflows/build.yml
+    with:
+      gpdb_repo: https://github.com/open-gpdb/gpdb.git
+      gpdb_ref: OPENGPDB_STABLE
+      cache_key: deps-open-gpdb-OPENGPDB_STABLE-arrow-15.0.2-grpc-1.62.3-gcc13-Linux-v4
+      artifact_name: tea-runtime-open-gpdb
+      open_gpdb: true
 
   smoke-tests-agp:
     needs: build-tea-agp
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - metadata_type: teapot
-            table_type: foreign
-            profile: ""
-          - metadata_type: teapot
-            table_type: external
-            profile: ""
-          - metadata_type: iceberg
-            table_type: foreign
-            profile: samovar
-          - metadata_type: iceberg
-            table_type: external
-            profile: samovar
-          - metadata_type: iceberg
-            table_type: foreign
-            profile: ""
+    uses: ./.github/workflows/smoke-tests.yml
+    with:
+      artifact_name: tea-runtime
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install runtime dependencies
-        run: bash ci/install-runtime-deps.sh
-
-      - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: tea-runtime
-          path: ci-artifacts
-
-      - name: Restore runtime files
-        run: bash ci/restore-runtime.sh
-
-      - name: Initialize Greenplum cluster
-        run: bash ci/start-cluster.sh --create-extension
-
-      - name: Start Iceberg services (Minio + HMS) and upload test data
-        run: bash ci/start-iceberg.sh
-
-      - name: Deploy tea config
-        run: bash ci/deploy-tea-config.sh
-
-      - name: Start Redis
-        run: |
-          sudo systemctl start redis-server
-          redis-cli ping
-
-      - name: Run smoke tests
-        run: bash ci/run-smoke.sh "${{ matrix.metadata_type }}" "${{ matrix.table_type }}" "${{ matrix.profile }}"
+  # Run the full tea smoke-test suite against open-gpdb. Kept separate (needs
+  # only build-tea-open-gpdb) so the arenadata smoke-tests do not wait on the
+  # open-gpdb build.
+  smoke-tests-open-gpdb:
+    needs: build-tea-open-gpdb
+    uses: ./.github/workflows/smoke-tests.yml
+    with:
+      artifact_name: tea-runtime-open-gpdb
 
   rest-tests-agp:
     needs: build-tea-agp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,33 +33,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clear cache
-        run: |
-          cd /opt
-          find . -maxdepth 1 -mindepth 1 '!' -path ./containerd '!' -path ./actionarchivecache '!' -path ./runner '!' -path ./runner-cache -exec rm -rf '{}' ';'
+        run: bash ci/clear-runner-cache.sh
 
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libapr1-dev \
-            libcurl4-openssl-dev \
-            libevent-dev \
-            libkrb5-dev \
-            libperl-dev \
-            libxerces-c-dev \
-            python2 \
-            python2-dev \
-            redis-server \
-            software-properties-common
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get install -y gcc-13 g++-13
-          sudo systemctl disable --now redis-server
+        run: bash ci/install-build-deps.sh
 
       - name: Prepare directories
-        run: |
-          mkdir -p $HOME/local build
-          sudo ln -s -f python2 /usr/bin/python
-          sudo locale-gen "en_US.UTF-8"
+        run: bash ci/prepare-dirs.sh
 
       - name: Cache installed dependencies
         id: cache-deps
@@ -77,70 +57,18 @@ jobs:
 
       - name: Build and install Greenplum 6
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/arenadata/gpdb.git -b 6.29.1_arenadata68 --depth 1
-          cd gpdb
-          git submodule update --init
-          : # TODO(gmusya): consider using --enable-cassert
-          ./configure --with-perl --with-python --with-libxml --with-gssapi --with-pythonsrc-ext --prefix=$HOME/local/gpdb
-          make -j8
-          make -j8 install
-          rm -rf gpdb
+        run: bash ci/build-gpdb.sh https://github.com/arenadata/gpdb.git 6.29.1_arenadata68
 
       - name: Build and install Arrow 15
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/apache/arrow.git -b maint-15.0.2 --depth 1
-          cd arrow
-          git apply ../vendor/arrow/fix_c-ares_url.patch
-          git apply ../vendor/arrow/like-dot-nl.patch
-          git apply ../vendor/arrow/ilike.patch
-          git apply ../vendor/arrow/snappy.patch
-          ./cpp/thirdparty/download_dependencies.sh ../build/arrow-thirdparty
-          mkdir cpp/build
-          cd cpp/build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/local \
-            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
-            -DARROW_BUILD_STATIC=ON -DARROW_BUILD_SHARED=OFF \
-            -DARROW_DEPENDENCY_SOURCE=BUNDLED -DARROW_NO_DEPRECTATED_API=ON \
-            -DARROW_LLVM_USE_SHARED=OFF -DARROW_FILESYSTEM=ON -DARROW_PARQUET=ON \
-            -DARROW_S3=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_LZ4=ON -DARROW_WITH_ZLIB=ON -DARROW_WITH_ZSTD=ON \
-            -DARROW_IPC=ON -DARROW_CSV=ON -DARROW_WITH_RAPIDJSON=ON \
-            -DARROW_GANDIVA=ON -DARROW_COMPUTE=ON ..
-          make -j8
-          make -j8 install
-          rm -rf arrow
+        run: bash ci/build-arrow.sh
 
       - name: Build and install gRPC
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/grpc/grpc.git -b v1.62.3 --depth 1
-          cd grpc
-          git submodule update --init --single-branch --depth 1
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/local \
-            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
-            -DgRPC_BUILD_SHARED_LIBS=OFF -DgRPC_BUILD_STATIC_LIBS=ON \
-            -DgRPC_BUILD_TESTS=OFF -DgRPC_BUILD_EXAMPLES=OFF \
-            -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
-            -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
-            -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
-            -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF  -DgRPC_SSL_PROVIDER:STRING=package ..
-          make -j8
-          make -j8 install
-          rm -rf grpc
+        run: bash ci/build-grpc.sh
 
       - name: Build Tea
-        run: |
-          cd build
-          cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DGreenplum_ROOT=$HOME/local/gpdb -DCMAKE_PREFIX_PATH=$HOME/local \
-            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
-            -DTEA_USE_THREAD_SANITIZER=OFF ..
-          ninja
-          ninja hive_metastore_server hive_metastore_client
-          ninja install
+        run: bash ci/build-tea.sh
 
       - name: Run unit tests
         run: |
@@ -148,13 +76,7 @@ jobs:
           ctest --output-on-failure
 
       - name: Pack runtime artifacts
-        run: |
-          mkdir -p ci-artifacts
-          tar -C "$HOME/local" -czf ci-artifacts/gpdb-with-tea.tar.gz gpdb
-          cp build/tea/smoke_test/smoke_test ci-artifacts/smoke_test
-          mkdir -p ci-artifacts/hms
-          install -m 0755 build/_deps/iceberg-cxx-build/tools/hive_metastore_server ci-artifacts/hms/hive_metastore_server
-          install -m 0755 build/_deps/iceberg-cxx-build/tools/hive_metastore_client ci-artifacts/hms/hive_metastore_client
+        run: bash ci/pack-artifacts.sh
 
       - name: Upload runtime artifacts
         uses: actions/upload-artifact@v4
@@ -177,33 +99,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Clear cache
-        run: |
-          cd /opt
-          find . -maxdepth 1 -mindepth 1 '!' -path ./containerd '!' -path ./actionarchivecache '!' -path ./runner '!' -path ./runner-cache -exec rm -rf '{}' ';'
+        run: bash ci/clear-runner-cache.sh
 
       - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libapr1-dev \
-            libcurl4-openssl-dev \
-            libevent-dev \
-            libkrb5-dev \
-            libperl-dev \
-            libxerces-c-dev \
-            python2 \
-            python2-dev \
-            redis-server \
-            software-properties-common
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get install -y gcc-13 g++-13
-          sudo systemctl disable --now redis-server
+        run: bash ci/install-build-deps.sh
 
       - name: Prepare directories
-        run: |
-          mkdir -p $HOME/local build
-          sudo ln -s -f python2 /usr/bin/python
-          sudo locale-gen "en_US.UTF-8"
+        run: bash ci/prepare-dirs.sh
 
       - name: Cache installed dependencies
         id: cache-deps
@@ -220,105 +122,25 @@ jobs:
           key: arrow-thirdparty-15.0.2
 
       - name: Free disk space
-        run: |
-          : # GitHub-hosted runners ship ~25 GB of preinstalled toolchains we
-          : # do not use; the from-source gpdb + Arrow + gRPC build plus tea
-          : # otherwise fills the disk and the final link fails with ENOSPC.
-          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
-            /usr/local/.ghcup /usr/share/swift /opt/hostedtoolcache/CodeQL || true
-          sudo docker image prune --all --force > /dev/null 2>&1 || true
+        run: bash ci/free-disk-space.sh
 
       - name: Build and install open-gpdb
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/open-gpdb/gpdb.git -b OPENGPDB_STABLE --depth 1
-          cd gpdb
-          git submodule update --init
-          : # tea's filter-pushdown tests depend on ORCA's qual ordering, so
-          : # ORCA must be built (NOT --disable-orca). ORCA uses -std=c++98/
-          : # gnu++98, but the system Xerces-C 3.2 (Ubuntu 22.04) requires
-          : # C++11 (char16_t); bump the ORCA C++ standard to gnu++14 (gnu++17
-          : # would reject ORCA's deprecated throw() specs). gnu++14 + -Wextra
-          : # then surfaces -Wdeprecated-copy / -Wnonnull-compare which ORCA's
-          : # -Werror turns fatal, so append -Wno-error=... last (wins over it).
-          for mk in src/backend/gpopt/gpopt.mk \
-                    src/backend/gporca/gporca.mk \
-                    src/backend/gporca/libgpos/src/common/Makefile; do
-            sed -i 's/-std=gnu++98/-std=gnu++14/g; s/-std=c++98/-std=gnu++14/g' "$mk"
-            printf '\noverride CPPFLAGS := $(CPPFLAGS) -Wno-error=deprecated-copy -Wno-error=nonnull-compare\n' >> "$mk"
-          done
-          : # open-gpdb defaults --with-mdblocales=yes and hard-requires the
-          : # mdblocales lib/header, which is not available on the CI image.
-          ./configure --with-perl --with-python --with-libxml --with-gssapi --with-pythonsrc-ext --without-mdblocales --prefix=$HOME/local/gpdb
-          : # src/common (FRONTEND) includes the backend-generated
-          : # utils/errcodes.h but has no order-only dep on it, so -j8 races
-          : # ("errcodes.h: No such file"). Force the generated header first.
-          make -C src/backend submake-errcodes
-          make -j8
-          make -j8 install
-          rm -rf gpdb
+        run: bash ci/build-gpdb.sh https://github.com/open-gpdb/gpdb.git OPENGPDB_STABLE open-gpdb
 
       - name: Build and install Arrow 15
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/apache/arrow.git -b maint-15.0.2 --depth 1
-          cd arrow
-          git apply ../vendor/arrow/fix_c-ares_url.patch
-          git apply ../vendor/arrow/like-dot-nl.patch
-          git apply ../vendor/arrow/ilike.patch
-          git apply ../vendor/arrow/snappy.patch
-          ./cpp/thirdparty/download_dependencies.sh ../build/arrow-thirdparty
-          mkdir cpp/build
-          cd cpp/build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/local \
-            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
-            -DARROW_BUILD_STATIC=ON -DARROW_BUILD_SHARED=OFF \
-            -DARROW_DEPENDENCY_SOURCE=BUNDLED -DARROW_NO_DEPRECTATED_API=ON \
-            -DARROW_LLVM_USE_SHARED=OFF -DARROW_FILESYSTEM=ON -DARROW_PARQUET=ON \
-            -DARROW_S3=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_LZ4=ON -DARROW_WITH_ZLIB=ON -DARROW_WITH_ZSTD=ON \
-            -DARROW_IPC=ON -DARROW_CSV=ON -DARROW_WITH_RAPIDJSON=ON \
-            -DARROW_GANDIVA=ON -DARROW_COMPUTE=ON ..
-          make -j8
-          make -j8 install
-          rm -rf arrow
+        run: bash ci/build-arrow.sh
 
       - name: Build and install gRPC
         if: steps.cache-deps.outputs.cache-hit != 'true'
-        run: |
-          git clone https://github.com/grpc/grpc.git -b v1.62.3 --depth 1
-          cd grpc
-          git submodule update --init --single-branch --depth 1
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/local \
-            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
-            -DgRPC_BUILD_SHARED_LIBS=OFF -DgRPC_BUILD_STATIC_LIBS=ON \
-            -DgRPC_BUILD_TESTS=OFF -DgRPC_BUILD_EXAMPLES=OFF \
-            -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
-            -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
-            -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
-            -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF  -DgRPC_SSL_PROVIDER:STRING=package ..
-          make -j8
-          make -j8 install
-          rm -rf grpc
+        run: bash ci/build-grpc.sh
 
       - name: Verify open-gpdb defines OPENGPDB
-        run: |
-          set -ex
-          # tea relies on this macro to select the open-gpdb sampling API.
-          grep -q '#define OPENGPDB' \
-            "$HOME/local/gpdb/include/postgresql/server/pg_config_manual.h"
+        run: bash ci/verify-opengpdb-define.sh
 
       - name: Build Tea against open-gpdb
-        run: |
-          cd build
-          cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DGreenplum_ROOT=$HOME/local/gpdb -DCMAKE_PREFIX_PATH=$HOME/local \
-            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
-            -DTEA_USE_THREAD_SANITIZER=OFF ..
-          ninja
-          ninja hive_metastore_server hive_metastore_client
-          ninja install
+        run: bash ci/build-tea.sh
 
       - name: Run unit tests
         run: |
@@ -326,13 +148,7 @@ jobs:
           ctest --output-on-failure
 
       - name: Pack runtime artifacts
-        run: |
-          mkdir -p ci-artifacts
-          tar -C "$HOME/local" -czf ci-artifacts/gpdb-with-tea.tar.gz gpdb
-          cp build/tea/smoke_test/smoke_test ci-artifacts/smoke_test
-          mkdir -p ci-artifacts/hms
-          install -m 0755 build/_deps/iceberg-cxx-build/tools/hive_metastore_server ci-artifacts/hms/hive_metastore_server
-          install -m 0755 build/_deps/iceberg-cxx-build/tools/hive_metastore_client ci-artifacts/hms/hive_metastore_client
+        run: bash ci/pack-artifacts.sh
 
       - name: Upload runtime artifacts
         uses: actions/upload-artifact@v4
@@ -373,18 +189,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install runtime dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libxerces-c3.2 \
-            python2 \
-            redis-server \
-            software-properties-common
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get install -y libstdc++6
-          sudo systemctl disable --now redis-server
-          sudo ln -s -f python2 /usr/bin/python
-          sudo locale-gen "en_US.UTF-8"
+        run: bash ci/install-runtime-deps.sh
 
       - name: Download runtime artifacts
         uses: actions/download-artifact@v4
@@ -393,44 +198,16 @@ jobs:
           path: ci-artifacts
 
       - name: Restore runtime files
-        run: |
-          mkdir -p "$HOME/local" build/tea/smoke_test build/hms
-          tar -xzf ci-artifacts/gpdb-with-tea.tar.gz -C "$HOME/local"
-          install -m 0755 ci-artifacts/smoke_test build/tea/smoke_test/smoke_test
-          install -m 0755 ci-artifacts/hms/hive_metastore_server build/hms/hive_metastore_server
-          install -m 0755 ci-artifacts/hms/hive_metastore_client build/hms/hive_metastore_client
+        run: bash ci/restore-runtime.sh
 
       - name: Initialize Greenplum cluster
-        run: |
-          sudo locale-gen "ru_RU.CP1251"
-          sudo mkdir -p /gpdata
-          sudo chown $USER /gpdata
-
-          source $HOME/local/gpdb/greenplum_path.sh
-          export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
-          NUM_SEGS=2 bash test/start-gp.sh $HOME/local/gpdb /gpdata
-
-          psql -d tea_ci -c 'CREATE EXTENSION tea;'
+        run: bash ci/start-cluster.sh --create-extension
 
       - name: Start Iceberg services (Minio + HMS) and upload test data
-        run: |
-          wget -q https://dl.min.io/server/minio/release/linux-amd64/minio -O /tmp/minio
-          wget -q https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc
-          chmod +x /tmp/minio /tmp/mc
-
-          export CI_PROJECT_DIR=$PWD
-          HMS_DIR="$CI_PROJECT_DIR/build/hms"
-
-          MINIO_EXECUTABLE=/tmp/minio MC_EXECUTABLE=/tmp/mc \
-          MINIO_DATA_DIR=/tmp/minio-data HMS_DIR="$HMS_DIR" \
-            bash test/iceberg/gen/init.sh
+        run: bash ci/start-iceberg.sh
 
       - name: Deploy tea config
-        run: |
-          source $HOME/local/gpdb/greenplum_path.sh
-          mkdir -p $GPHOME/tea
-          cp test/config/tea-config.json $GPHOME/tea/tea-config.json
-          cp test/config/tea-config-schema.json $GPHOME/tea/tea-config-schema.json
+        run: bash ci/deploy-tea-config.sh
 
       - name: Start Redis
         run: |
@@ -438,13 +215,7 @@ jobs:
           redis-cli ping
 
       - name: Run smoke tests
-        run: |
-          source $HOME/local/gpdb/greenplum_path.sh
-          export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
-          build/tea/smoke_test/smoke_test \
-            --metadata_type=${{ matrix.metadata_type }} \
-            --table_type=${{ matrix.table_type }} \
-            --profile=${{ matrix.profile }}
+        run: bash ci/run-smoke.sh "${{ matrix.metadata_type }}" "${{ matrix.table_type }}" "${{ matrix.profile }}"
 
   smoke-tests-agp:
     needs: build-tea-agp
@@ -469,24 +240,12 @@ jobs:
             table_type: foreign
             profile: ""
 
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Install runtime dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libxerces-c3.2 \
-            python2 \
-            redis-server \
-            software-properties-common
-          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt-get install -y libstdc++6
-          sudo systemctl disable --now redis-server
-          sudo ln -s -f python2 /usr/bin/python
-          sudo locale-gen "en_US.UTF-8"
+        run: bash ci/install-runtime-deps.sh
 
       - name: Download runtime artifacts
         uses: actions/download-artifact@v4
@@ -495,45 +254,16 @@ jobs:
           path: ci-artifacts
 
       - name: Restore runtime files
-        run: |
-          mkdir -p "$HOME/local" build/tea/smoke_test build/hms
-          tar -xzf ci-artifacts/gpdb-with-tea.tar.gz -C "$HOME/local"
-          install -m 0755 ci-artifacts/smoke_test build/tea/smoke_test/smoke_test
-          install -m 0755 ci-artifacts/hms/hive_metastore_server build/hms/hive_metastore_server
-          install -m 0755 ci-artifacts/hms/hive_metastore_client build/hms/hive_metastore_client
+        run: bash ci/restore-runtime.sh
 
       - name: Initialize Greenplum cluster
-        run: |
-          : # TODO(gmusya): consider using make create-demo-cluster
-          sudo locale-gen "ru_RU.CP1251"
-          sudo mkdir -p /gpdata
-          sudo chown $USER /gpdata
-
-          source $HOME/local/gpdb/greenplum_path.sh
-          export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
-          NUM_SEGS=2 bash test/start-gp.sh $HOME/local/gpdb /gpdata
-
-          psql -d tea_ci -c 'CREATE EXTENSION tea;'
+        run: bash ci/start-cluster.sh --create-extension
 
       - name: Start Iceberg services (Minio + HMS) and upload test data
-        run: |
-          wget -q https://dl.min.io/server/minio/release/linux-amd64/minio -O /tmp/minio
-          wget -q https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc
-          chmod +x /tmp/minio /tmp/mc
-
-          export CI_PROJECT_DIR=$PWD
-          HMS_DIR="$CI_PROJECT_DIR/build/hms"
-
-          MINIO_EXECUTABLE=/tmp/minio MC_EXECUTABLE=/tmp/mc \
-          MINIO_DATA_DIR=/tmp/minio-data HMS_DIR="$HMS_DIR" \
-            bash test/iceberg/gen/init.sh
+        run: bash ci/start-iceberg.sh
 
       - name: Deploy tea config
-        run: |
-          source $HOME/local/gpdb/greenplum_path.sh
-          mkdir -p $GPHOME/tea
-          cp test/config/tea-config.json $GPHOME/tea/tea-config.json
-          cp test/config/tea-config-schema.json $GPHOME/tea/tea-config-schema.json
+        run: bash ci/deploy-tea-config.sh
 
       - name: Start Redis
         run: |
@@ -541,13 +271,7 @@ jobs:
           redis-cli ping
 
       - name: Run smoke tests
-        run: |
-          source $HOME/local/gpdb/greenplum_path.sh
-          export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
-          build/tea/smoke_test/smoke_test \
-            --metadata_type=${{ matrix.metadata_type }} \
-            --table_type=${{ matrix.table_type }} \
-            --profile=${{ matrix.profile }}
+        run: bash ci/run-smoke.sh "${{ matrix.metadata_type }}" "${{ matrix.table_type }}" "${{ matrix.profile }}"
 
   rest-tests-agp:
     needs: build-tea-agp
@@ -584,15 +308,7 @@ jobs:
           tar -xzf ci-artifacts/gpdb-with-tea.tar.gz -C "$HOME/local"
 
       - name: Initialize Greenplum cluster
-        run: |
-          : # TODO(gmusya): consider using make create-demo-cluster
-          sudo locale-gen "ru_RU.CP1251"
-          sudo mkdir -p /gpdata
-          sudo chown $USER /gpdata
-
-          source $HOME/local/gpdb/greenplum_path.sh
-          export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
-          NUM_SEGS=2 bash test/start-gp.sh $HOME/local/gpdb /gpdata
+        run: bash ci/start-cluster.sh
 
       - name: Start Minio and upload test data
         run: |
@@ -607,11 +323,7 @@ jobs:
             bash test/iceberg/gen/init_minio.sh
 
       - name: Deploy tea config
-        run: |
-          source $HOME/local/gpdb/greenplum_path.sh
-          mkdir -p $GPHOME/tea
-          cp test/config/tea-config-rest.json $GPHOME/tea/tea-config.json
-          cp test/config/tea-config-schema.json $GPHOME/tea/tea-config-schema.json
+        run: bash ci/deploy-tea-config.sh test/config/tea-config-rest.json
 
       - name: Start Lakekeeper
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             ':!:vendor/**' \
             | xargs -r clang-format --dry-run -Werror
 
-  build-tea:
+  build-tea-agp:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -163,8 +163,291 @@ jobs:
           path: ci-artifacts
           retention-days: 1
 
-  smoke-tests:
-    needs: build-tea
+  # Build tea against open-gpdb (instead of arenadata/gpdb) to make sure it
+  # keeps compiling/linking there. open-gpdb diverges from other Greenplum
+  # forks (e.g. it moved the sampling helpers into utils/sampling.h and
+  # removed the legacy anl_* API); tea selects the right API via the OPENGPDB
+  # macro that open-gpdb defines in pg_config_manual.h. This job guards that
+  # path. NOTE: it requires the OPENGPDB define to be present in the cloned
+  # open-gpdb branch.
+  build-tea-open-gpdb:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Clear cache
+        run: |
+          cd /opt
+          find . -maxdepth 1 -mindepth 1 '!' -path ./containerd '!' -path ./actionarchivecache '!' -path ./runner '!' -path ./runner-cache -exec rm -rf '{}' ';'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libapr1-dev \
+            libcurl4-openssl-dev \
+            libevent-dev \
+            libkrb5-dev \
+            libperl-dev \
+            libxerces-c-dev \
+            python2 \
+            python2-dev \
+            redis-server \
+            software-properties-common
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get install -y gcc-13 g++-13
+          sudo systemctl disable --now redis-server
+
+      - name: Prepare directories
+        run: |
+          mkdir -p $HOME/local build
+          sudo ln -s -f python2 /usr/bin/python
+          sudo locale-gen "en_US.UTF-8"
+
+      - name: Cache installed dependencies
+        id: cache-deps
+        uses: actions/cache@v4
+        with:
+          path: ~/local
+          key: deps-open-gpdb-OPENGPDB_STABLE-arrow-15.0.2-grpc-1.62.3-gcc13-${{ runner.os }}-v4
+
+      - name: Cache Arrow third-party downloads
+        id: cache-arrow-thirdparty
+        uses: actions/cache@v4
+        with:
+          path: build/arrow-thirdparty
+          key: arrow-thirdparty-15.0.2
+
+      - name: Free disk space
+        run: |
+          : # GitHub-hosted runners ship ~25 GB of preinstalled toolchains we
+          : # do not use; the from-source gpdb + Arrow + gRPC build plus tea
+          : # otherwise fills the disk and the final link fails with ENOSPC.
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /usr/share/swift /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force > /dev/null 2>&1 || true
+
+      - name: Build and install open-gpdb
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/open-gpdb/gpdb.git -b OPENGPDB_STABLE --depth 1
+          cd gpdb
+          git submodule update --init
+          : # tea's filter-pushdown tests depend on ORCA's qual ordering, so
+          : # ORCA must be built (NOT --disable-orca). ORCA uses -std=c++98/
+          : # gnu++98, but the system Xerces-C 3.2 (Ubuntu 22.04) requires
+          : # C++11 (char16_t); bump the ORCA C++ standard to gnu++14 (gnu++17
+          : # would reject ORCA's deprecated throw() specs). gnu++14 + -Wextra
+          : # then surfaces -Wdeprecated-copy / -Wnonnull-compare which ORCA's
+          : # -Werror turns fatal, so append -Wno-error=... last (wins over it).
+          for mk in src/backend/gpopt/gpopt.mk \
+                    src/backend/gporca/gporca.mk \
+                    src/backend/gporca/libgpos/src/common/Makefile; do
+            sed -i 's/-std=gnu++98/-std=gnu++14/g; s/-std=c++98/-std=gnu++14/g' "$mk"
+            printf '\noverride CPPFLAGS := $(CPPFLAGS) -Wno-error=deprecated-copy -Wno-error=nonnull-compare\n' >> "$mk"
+          done
+          : # open-gpdb defaults --with-mdblocales=yes and hard-requires the
+          : # mdblocales lib/header, which is not available on the CI image.
+          ./configure --with-perl --with-python --with-libxml --with-gssapi --with-pythonsrc-ext --without-mdblocales --prefix=$HOME/local/gpdb
+          : # src/common (FRONTEND) includes the backend-generated
+          : # utils/errcodes.h but has no order-only dep on it, so -j8 races
+          : # ("errcodes.h: No such file"). Force the generated header first.
+          make -C src/backend submake-errcodes
+          make -j8
+          make -j8 install
+          rm -rf gpdb
+
+      - name: Build and install Arrow 15
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/apache/arrow.git -b maint-15.0.2 --depth 1
+          cd arrow
+          git apply ../vendor/arrow/fix_c-ares_url.patch
+          git apply ../vendor/arrow/like-dot-nl.patch
+          git apply ../vendor/arrow/ilike.patch
+          git apply ../vendor/arrow/snappy.patch
+          ./cpp/thirdparty/download_dependencies.sh ../build/arrow-thirdparty
+          mkdir cpp/build
+          cd cpp/build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/local \
+            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
+            -DARROW_BUILD_STATIC=ON -DARROW_BUILD_SHARED=OFF \
+            -DARROW_DEPENDENCY_SOURCE=BUNDLED -DARROW_NO_DEPRECTATED_API=ON \
+            -DARROW_LLVM_USE_SHARED=OFF -DARROW_FILESYSTEM=ON -DARROW_PARQUET=ON \
+            -DARROW_S3=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_LZ4=ON -DARROW_WITH_ZLIB=ON -DARROW_WITH_ZSTD=ON \
+            -DARROW_IPC=ON -DARROW_CSV=ON -DARROW_WITH_RAPIDJSON=ON \
+            -DARROW_GANDIVA=ON -DARROW_COMPUTE=ON ..
+          make -j8
+          make -j8 install
+          rm -rf arrow
+
+      - name: Build and install gRPC
+        if: steps.cache-deps.outputs.cache-hit != 'true'
+        run: |
+          git clone https://github.com/grpc/grpc.git -b v1.62.3 --depth 1
+          cd grpc
+          git submodule update --init --single-branch --depth 1
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/local \
+            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
+            -DgRPC_BUILD_SHARED_LIBS=OFF -DgRPC_BUILD_STATIC_LIBS=ON \
+            -DgRPC_BUILD_TESTS=OFF -DgRPC_BUILD_EXAMPLES=OFF \
+            -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+            -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+            -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
+            -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF  -DgRPC_SSL_PROVIDER:STRING=package ..
+          make -j8
+          make -j8 install
+          rm -rf grpc
+
+      - name: Verify open-gpdb defines OPENGPDB
+        run: |
+          set -ex
+          # tea relies on this macro to select the open-gpdb sampling API.
+          grep -q '#define OPENGPDB' \
+            "$HOME/local/gpdb/include/postgresql/server/pg_config_manual.h"
+
+      - name: Build Tea against open-gpdb
+        run: |
+          cd build
+          cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DGreenplum_ROOT=$HOME/local/gpdb -DCMAKE_PREFIX_PATH=$HOME/local \
+            -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
+            -DTEA_USE_THREAD_SANITIZER=OFF ..
+          ninja
+          ninja hive_metastore_server hive_metastore_client
+          ninja install
+
+      - name: Run unit tests
+        run: |
+          cd build
+          ctest --output-on-failure
+
+      - name: Pack runtime artifacts
+        run: |
+          mkdir -p ci-artifacts
+          tar -C "$HOME/local" -czf ci-artifacts/gpdb-with-tea.tar.gz gpdb
+          cp build/tea/smoke_test/smoke_test ci-artifacts/smoke_test
+          mkdir -p ci-artifacts/hms
+          install -m 0755 build/_deps/iceberg-cxx-build/tools/hive_metastore_server ci-artifacts/hms/hive_metastore_server
+          install -m 0755 build/_deps/iceberg-cxx-build/tools/hive_metastore_client ci-artifacts/hms/hive_metastore_client
+
+      - name: Upload runtime artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tea-runtime-open-gpdb
+          path: ci-artifacts
+          retention-days: 1
+
+  # Run the full tea smoke-test suite (not just ANALYZE) against open-gpdb.
+  # Mirrors the smoke-tests job below, which only covers arenadata/gpdb.
+  # Kept as a separate job (needs only build-tea-open-gpdb) so the arenadata
+  # smoke-tests do not wait on the open-gpdb build.
+  smoke-tests-open-gpdb:
+    needs: build-tea-open-gpdb
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - metadata_type: teapot
+            table_type: foreign
+            profile: ""
+          - metadata_type: teapot
+            table_type: external
+            profile: ""
+          - metadata_type: iceberg
+            table_type: foreign
+            profile: samovar
+          - metadata_type: iceberg
+            table_type: external
+            profile: samovar
+          - metadata_type: iceberg
+            table_type: foreign
+            profile: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install runtime dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxerces-c3.2 \
+            python2 \
+            redis-server \
+            software-properties-common
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get install -y libstdc++6
+          sudo systemctl disable --now redis-server
+          sudo ln -s -f python2 /usr/bin/python
+          sudo locale-gen "en_US.UTF-8"
+
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: tea-runtime-open-gpdb
+          path: ci-artifacts
+
+      - name: Restore runtime files
+        run: |
+          mkdir -p "$HOME/local" build/tea/smoke_test build/hms
+          tar -xzf ci-artifacts/gpdb-with-tea.tar.gz -C "$HOME/local"
+          install -m 0755 ci-artifacts/smoke_test build/tea/smoke_test/smoke_test
+          install -m 0755 ci-artifacts/hms/hive_metastore_server build/hms/hive_metastore_server
+          install -m 0755 ci-artifacts/hms/hive_metastore_client build/hms/hive_metastore_client
+
+      - name: Initialize Greenplum cluster
+        run: |
+          sudo locale-gen "ru_RU.CP1251"
+          sudo mkdir -p /gpdata
+          sudo chown $USER /gpdata
+
+          source $HOME/local/gpdb/greenplum_path.sh
+          export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
+          NUM_SEGS=2 bash test/start-gp.sh $HOME/local/gpdb /gpdata
+
+          psql -d tea_ci -c 'CREATE EXTENSION tea;'
+
+      - name: Start Iceberg services (Minio + HMS) and upload test data
+        run: |
+          wget -q https://dl.min.io/server/minio/release/linux-amd64/minio -O /tmp/minio
+          wget -q https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc
+          chmod +x /tmp/minio /tmp/mc
+
+          export CI_PROJECT_DIR=$PWD
+          HMS_DIR="$CI_PROJECT_DIR/build/hms"
+
+          MINIO_EXECUTABLE=/tmp/minio MC_EXECUTABLE=/tmp/mc \
+          MINIO_DATA_DIR=/tmp/minio-data HMS_DIR="$HMS_DIR" \
+            bash test/iceberg/gen/init.sh
+
+      - name: Deploy tea config
+        run: |
+          source $HOME/local/gpdb/greenplum_path.sh
+          mkdir -p $GPHOME/tea
+          cp test/config/tea-config.json $GPHOME/tea/tea-config.json
+          cp test/config/tea-config-schema.json $GPHOME/tea/tea-config-schema.json
+
+      - name: Start Redis
+        run: |
+          sudo systemctl start redis-server
+          redis-cli ping
+
+      - name: Run smoke tests
+        run: |
+          source $HOME/local/gpdb/greenplum_path.sh
+          export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
+          build/tea/smoke_test/smoke_test \
+            --metadata_type=${{ matrix.metadata_type }} \
+            --table_type=${{ matrix.table_type }} \
+            --profile=${{ matrix.profile }}
+
+  smoke-tests-agp:
+    needs: build-tea-agp
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -266,8 +549,8 @@ jobs:
             --table_type=${{ matrix.table_type }} \
             --profile=${{ matrix.profile }}
 
-  rest-tests:
-    needs: build-tea
+  rest-tests-agp:
+    needs: build-tea-agp
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,67 @@
+name: smoke-tests
+
+# Reusable workflow: run the full tea smoke-test suite against a prebuilt
+# runtime artifact. Called by ci.yml once per fork (arenadata + open-gpdb).
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        description: Name of the runtime artifact to download
+        required: true
+        type: string
+
+jobs:
+  smoke:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - metadata_type: teapot
+            table_type: foreign
+            profile: ""
+          - metadata_type: teapot
+            table_type: external
+            profile: ""
+          - metadata_type: iceberg
+            table_type: foreign
+            profile: samovar
+          - metadata_type: iceberg
+            table_type: external
+            profile: samovar
+          - metadata_type: iceberg
+            table_type: foreign
+            profile: ""
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install runtime dependencies
+        run: bash ci/install-runtime-deps.sh
+
+      - name: Download runtime artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ci-artifacts
+
+      - name: Restore runtime files
+        run: bash ci/restore-runtime.sh
+
+      - name: Initialize Greenplum cluster
+        run: bash ci/start-cluster.sh --create-extension
+
+      - name: Start Iceberg services (Minio + HMS) and upload test data
+        run: bash ci/start-iceberg.sh
+
+      - name: Deploy tea config
+        run: bash ci/deploy-tea-config.sh
+
+      - name: Start Redis
+        run: |
+          sudo systemctl start redis-server
+          redis-cli ping
+
+      - name: Run smoke tests
+        run: bash ci/run-smoke.sh "${{ matrix.metadata_type }}" "${{ matrix.table_type }}" "${{ matrix.profile }}"

--- a/ci/build-arrow.sh
+++ b/ci/build-arrow.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Build and install a static Apache Arrow 15 into $HOME/local. Third-party
+# downloads land in build/arrow-thirdparty (cached by the workflow).
+set -eo pipefail
+
+git clone https://github.com/apache/arrow.git -b maint-15.0.2 --depth 1
+cd arrow
+git apply ../vendor/arrow/fix_c-ares_url.patch
+git apply ../vendor/arrow/like-dot-nl.patch
+git apply ../vendor/arrow/ilike.patch
+git apply ../vendor/arrow/snappy.patch
+./cpp/thirdparty/download_dependencies.sh ../build/arrow-thirdparty
+mkdir cpp/build
+cd cpp/build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$HOME/local" \
+  -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
+  -DARROW_BUILD_STATIC=ON -DARROW_BUILD_SHARED=OFF \
+  -DARROW_DEPENDENCY_SOURCE=BUNDLED -DARROW_NO_DEPRECTATED_API=ON \
+  -DARROW_LLVM_USE_SHARED=OFF -DARROW_FILESYSTEM=ON -DARROW_PARQUET=ON \
+  -DARROW_S3=ON -DARROW_WITH_SNAPPY=ON -DARROW_WITH_LZ4=ON -DARROW_WITH_ZLIB=ON -DARROW_WITH_ZSTD=ON \
+  -DARROW_IPC=ON -DARROW_CSV=ON -DARROW_WITH_RAPIDJSON=ON \
+  -DARROW_GANDIVA=ON -DARROW_COMPUTE=ON ..
+make -j8
+make -j8 install
+
+cd ../../..
+rm -rf arrow

--- a/ci/build-gpdb.sh
+++ b/ci/build-gpdb.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Build and install Greenplum 6 into $HOME/local/gpdb.
+#
+# Usage: build-gpdb.sh <repo-url> <ref> [open-gpdb]
+#
+# Passing "open-gpdb" as the third argument enables the fixups needed for the
+# open-gpdb fork (see the inline comments below); arenadata/gpdb builds without
+# them.
+set -eo pipefail
+
+repo="$1"
+ref="$2"
+mode="${3:-}"
+
+git clone "$repo" -b "$ref" --depth 1 gpdb
+cd gpdb
+git submodule update --init
+
+configure_extra=()
+if [ "$mode" = "open-gpdb" ]; then
+  # ORCA in open-gpdb still builds with -std=c++98/gnu++98, but the system
+  # Xerces-C 3.2 (Ubuntu 22.04) requires C++11 (char16_t); bump the ORCA C++
+  # standard to gnu++14 (gnu++17 would reject ORCA's deprecated throw() specs).
+  # gnu++14 + -Wextra then surfaces -Wdeprecated-copy / -Wnonnull-compare which
+  # ORCA's -Werror turns fatal, so append -Wno-error=... last (wins over it).
+  for mk in src/backend/gpopt/gpopt.mk \
+            src/backend/gporca/gporca.mk \
+            src/backend/gporca/libgpos/src/common/Makefile; do
+    sed -i 's/-std=gnu++98/-std=gnu++14/g; s/-std=c++98/-std=gnu++14/g' "$mk"
+    printf '\noverride CPPFLAGS := $(CPPFLAGS) -Wno-error=deprecated-copy -Wno-error=nonnull-compare\n' >> "$mk"
+  done
+  # open-gpdb defaults --with-mdblocales=yes and hard-requires the mdblocales
+  # lib/header, which is not available on the CI image.
+  configure_extra+=(--without-mdblocales)
+fi
+
+# TODO(gmusya): consider using --enable-cassert
+./configure --with-perl --with-python --with-libxml --with-gssapi \
+  --with-pythonsrc-ext "${configure_extra[@]}" --prefix="$HOME/local/gpdb"
+
+if [ "$mode" = "open-gpdb" ]; then
+  # src/common (FRONTEND) includes the backend-generated utils/errcodes.h but
+  # has no order-only dep on it, so -j8 races ("errcodes.h: No such file").
+  # Force the generated header first.
+  make -C src/backend submake-errcodes
+fi
+
+make -j8
+make -j8 install
+
+cd ..
+rm -rf gpdb

--- a/ci/build-grpc.sh
+++ b/ci/build-grpc.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Build and install a static gRPC 1.62.3 into $HOME/local.
+set -eo pipefail
+
+git clone https://github.com/grpc/grpc.git -b v1.62.3 --depth 1
+cd grpc
+git submodule update --init --single-branch --depth 1
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX="$HOME/local" \
+  -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
+  -DgRPC_BUILD_SHARED_LIBS=OFF -DgRPC_BUILD_STATIC_LIBS=ON \
+  -DgRPC_BUILD_TESTS=OFF -DgRPC_BUILD_EXAMPLES=OFF \
+  -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+  -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+  -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
+  -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF  -DgRPC_SSL_PROVIDER:STRING=package ..
+make -j8
+make -j8 install
+
+cd ../..
+rm -rf grpc

--- a/ci/build-tea.sh
+++ b/ci/build-tea.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Configure and build tea against the gpdb installed in $HOME/local/gpdb.
+set -eo pipefail
+
+cd build
+cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+  -DGreenplum_ROOT="$HOME/local/gpdb" -DCMAKE_PREFIX_PATH="$HOME/local" \
+  -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
+  -DTEA_USE_THREAD_SANITIZER=OFF ..
+ninja
+ninja hive_metastore_server hive_metastore_client
+ninja install

--- a/ci/clear-runner-cache.sh
+++ b/ci/clear-runner-cache.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Self-hosted runners persist state between jobs; wipe /opt (keeping the
+# actions-runner's own directories) so each build starts from a clean slate.
+set -eo pipefail
+
+cd /opt
+find . -maxdepth 1 -mindepth 1 \
+  '!' -path ./containerd \
+  '!' -path ./actionarchivecache \
+  '!' -path ./runner \
+  '!' -path ./runner-cache \
+  -exec rm -rf '{}' ';'

--- a/ci/deploy-tea-config.sh
+++ b/ci/deploy-tea-config.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Deploy the tea config into $GPHOME/tea.
+#
+# Usage: deploy-tea-config.sh [config-file]
+#
+# Defaults to test/config/tea-config.json (smoke tests); the REST test passes
+# test/config/tea-config-rest.json.
+set -eo pipefail
+
+config="${1:-test/config/tea-config.json}"
+
+source "$HOME/local/gpdb/greenplum_path.sh"
+mkdir -p "$GPHOME/tea"
+cp "$config" "$GPHOME/tea/tea-config.json"
+cp test/config/tea-config-schema.json "$GPHOME/tea/tea-config-schema.json"

--- a/ci/free-disk-space.sh
+++ b/ci/free-disk-space.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# GitHub-hosted runners ship ~25 GB of preinstalled toolchains we do not use;
+# the from-source gpdb + Arrow + gRPC build plus tea otherwise fills the disk
+# and the final link fails with ENOSPC. Reclaim the space before building.
+set -eo pipefail
+
+sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+  /usr/local/.ghcup /usr/share/swift /opt/hostedtoolcache/CodeQL || true
+sudo docker image prune --all --force > /dev/null 2>&1 || true

--- a/ci/install-build-deps.sh
+++ b/ci/install-build-deps.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install the build-time dependencies needed to compile gpdb, Arrow, gRPC and
+# tea from source (shared by every build job).
+set -eo pipefail
+
+sudo apt-get update
+sudo apt-get install -y \
+  libapr1-dev \
+  libcurl4-openssl-dev \
+  libevent-dev \
+  libkrb5-dev \
+  libperl-dev \
+  libxerces-c-dev \
+  python2 \
+  python2-dev \
+  redis-server \
+  software-properties-common
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt-get install -y gcc-13 g++-13
+sudo systemctl disable --now redis-server

--- a/ci/install-runtime-deps.sh
+++ b/ci/install-runtime-deps.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Install the runtime dependencies needed to start a gpdb cluster and run the
+# smoke tests (shared by the smoke-test jobs).
+set -eo pipefail
+
+sudo apt-get update
+sudo apt-get install -y \
+  libxerces-c3.2 \
+  python2 \
+  redis-server \
+  software-properties-common
+sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+sudo apt-get install -y libstdc++6
+sudo systemctl disable --now redis-server
+sudo ln -s -f python2 /usr/bin/python
+sudo locale-gen "en_US.UTF-8"

--- a/ci/pack-artifacts.sh
+++ b/ci/pack-artifacts.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Pack the runtime artifacts (installed gpdb+tea, the smoke_test binary and the
+# Hive Metastore tools) into ci-artifacts/ for the downstream test jobs.
+set -eo pipefail
+
+mkdir -p ci-artifacts
+tar -C "$HOME/local" -czf ci-artifacts/gpdb-with-tea.tar.gz gpdb
+cp build/tea/smoke_test/smoke_test ci-artifacts/smoke_test
+mkdir -p ci-artifacts/hms
+install -m 0755 build/_deps/iceberg-cxx-build/tools/hive_metastore_server ci-artifacts/hms/hive_metastore_server
+install -m 0755 build/_deps/iceberg-cxx-build/tools/hive_metastore_client ci-artifacts/hms/hive_metastore_client

--- a/ci/prepare-dirs.sh
+++ b/ci/prepare-dirs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Create the build/install directories and set up python2 + locale (shared by
+# every build job).
+set -eo pipefail
+
+mkdir -p "$HOME/local" build
+sudo ln -s -f python2 /usr/bin/python
+sudo locale-gen "en_US.UTF-8"

--- a/ci/restore-runtime.sh
+++ b/ci/restore-runtime.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Unpack the runtime artifacts produced by the build job: the installed
+# gpdb+tea, the smoke_test binary and the Hive Metastore tools.
+set -eo pipefail
+
+mkdir -p "$HOME/local" build/tea/smoke_test build/hms
+tar -xzf ci-artifacts/gpdb-with-tea.tar.gz -C "$HOME/local"
+install -m 0755 ci-artifacts/smoke_test build/tea/smoke_test/smoke_test
+install -m 0755 ci-artifacts/hms/hive_metastore_server build/hms/hive_metastore_server
+install -m 0755 ci-artifacts/hms/hive_metastore_client build/hms/hive_metastore_client

--- a/ci/run-smoke.sh
+++ b/ci/run-smoke.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Run the tea smoke_test binary for one matrix combination.
+#
+# Usage: run-smoke.sh <metadata_type> <table_type> <profile>
+set -eo pipefail
+
+source "$HOME/local/gpdb/greenplum_path.sh"
+export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
+build/tea/smoke_test/smoke_test \
+  --metadata_type="$1" \
+  --table_type="$2" \
+  --profile="$3"

--- a/ci/start-cluster.sh
+++ b/ci/start-cluster.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Initialize and start a 2-segment demo gpdb cluster in /gpdata.
+#
+# Usage: start-cluster.sh [--create-extension]
+#
+# Pass --create-extension to also run "CREATE EXTENSION tea" in tea_ci (the
+# smoke tests need it; the REST test creates the extension itself later).
+set -eo pipefail
+
+# TODO(gmusya): consider using make create-demo-cluster
+sudo locale-gen "ru_RU.CP1251"
+sudo mkdir -p /gpdata
+sudo chown "$USER" /gpdata
+
+source "$HOME/local/gpdb/greenplum_path.sh"
+export MASTER_DATA_DIRECTORY=/gpdata/master/gpsne-1
+NUM_SEGS=2 bash test/start-gp.sh "$HOME/local/gpdb" /gpdata
+
+if [ "${1:-}" = "--create-extension" ]; then
+  psql -d tea_ci -c 'CREATE EXTENSION tea;'
+fi

--- a/ci/start-iceberg.sh
+++ b/ci/start-iceberg.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Download Minio + mc, then bring up the Iceberg services (Minio + Hive
+# Metastore) and upload the test data.
+set -eo pipefail
+
+wget -q https://dl.min.io/server/minio/release/linux-amd64/minio -O /tmp/minio
+wget -q https://dl.min.io/client/mc/release/linux-amd64/mc -O /tmp/mc
+chmod +x /tmp/minio /tmp/mc
+
+export CI_PROJECT_DIR="$PWD"
+HMS_DIR="$CI_PROJECT_DIR/build/hms"
+
+MINIO_EXECUTABLE=/tmp/minio MC_EXECUTABLE=/tmp/mc \
+MINIO_DATA_DIR=/tmp/minio-data HMS_DIR="$HMS_DIR" \
+  bash test/iceberg/gen/init.sh

--- a/ci/verify-opengpdb-define.sh
+++ b/ci/verify-opengpdb-define.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# tea relies on the OPENGPDB macro (defined in pg_config_manual.h) to select
+# the open-gpdb sampling API; make sure the freshly built gpdb defines it.
+set -ex
+
+grep -q '#define OPENGPDB' \
+  "$HOME/local/gpdb/include/postgresql/server/pg_config_manual.h"

--- a/tea/gpext/tea_fdw.c
+++ b/tea/gpext/tea_fdw.c
@@ -37,6 +37,11 @@
 #include "utils/memutils.h"
 #include "utils/palloc.h"
 #include "utils/rel.h"
+#ifdef OPENGPDB
+/* open-gpdb moved the sampling helpers into their own public header;
+ * Greengage 6 still declares the legacy anl_* API in commands/vacuum.h */
+#include "utils/sampling.h"
+#endif
 
 #include "tea/filter/gp/convert.h"
 #include "tea/gpext/tea_column.h"
@@ -860,7 +865,12 @@ static int TeaAcquireSampleRowsFunc(Relation relation, int elevel, HeapTuple* ro
    * see Jeff Vitter's paper.
    */
   double rowstoskip = 0;
-  double rstate = 0;
+#ifdef OPENGPDB
+  ReservoirStateData rstate;
+  reservoir_init_selection_state(&rstate, targrows);
+#else
+  double rstate = 0; /* Greengage 6: legacy anl_* API */
+#endif
   while (has_row) {
     CHECK_FOR_INTERRUPTS();
 
@@ -877,13 +887,21 @@ static int TeaAcquireSampleRowsFunc(Relation relation, int elevel, HeapTuple* ro
     samplerows += 1;
     rowstoskip -= 1;
     if (rowstoskip < 0) {
+#ifdef OPENGPDB
+      rowstoskip = reservoir_get_next_S(&rstate, samplerows, targrows);
+#else
       rowstoskip = anl_get_next_S(samplerows, targrows, &rstate);
+#endif
     }
     const bool replace_element = (rowstoskip <= 0);
 
     if (replace_element) {
       /* Choose a random reservoir element to replace. */
+#ifdef OPENGPDB
+      int pos = (int)(targrows * sampler_random_fract());
+#else
       int pos = (int)(targrows * anl_random_fract());
+#endif
       Assert(pos >= 0 && pos < targrows);
       heap_freetuple(rows[pos]);
 


### PR DESCRIPTION
fdw: select reservoir_* sampling API on open-gpdb under #ifdef OPENGPDB
    
open-gpdb renamed the anl_* sampling helpers; use the new names there
and keep anl_* for ADB 6.

ci: build and run the smoke-test suite against open-gpdb