### PR TITLE
Fix duplicate environment variable loading in config

### DIFF
--- a/tea/common/config.cpp
+++ b/tea/common/config.cpp
@@ -496,7 +496,6 @@ arrow::Status ReadValues(Source* src, Config* config, std::string_view section_p
 }
 
 arrow::Status Load(const rapidjson::Document& document, std::string_view profile, Config* config) {
-  LoadEnvDefaults(config);
   if (!document.IsObject()) {
     return arrow::Status::ExecutionError("Invalid tea-config.json flie: root is not an object");
   }


### PR DESCRIPTION
Remove redundant LoadEnvDefaults call from the JSON load function. Environment variables are now correctly initialized only once in ConfigSource::GetConfig before parsing the configuration file, preventing unnecessary double execution.