### PR TITLE
Add tea docker build container

### DIFF
--- a/.github/workflows/docker-tea-build-containers.yml
+++ b/.github/workflows/docker-tea-build-containers.yml
@@ -1,0 +1,155 @@
+# --------------------------------------------------------------------
+# GitHub Actions Workflow for Tea Build Environment Images
+# --------------------------------------------------------------------
+# Purpose:
+# Builds, tests, and publishes Docker images used to compile Tea.
+# Images are based on open-gpdb jammy, pre-install Arrow/gRPC and
+# toolchains, and are validated with TestInfra before publish.
+#
+# Image Tags (GHCR):
+# - Latest: tea-build-ubuntu22.04-latest
+# - Versioned: tea-build-ubuntu22.04-{YYYYMMDD}-{git-short-sha}
+#
+# Features:
+# - Path filtering so unrelated changes skip the build
+# - TestInfra validation before push
+# - Push only from main (PRs build + test only)
+# --------------------------------------------------------------------
+
+name: docker-tea-build-containers
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'devops/build/ubuntu22.04/**'
+  pull_request:
+    paths:
+      - 'devops/build/**'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-tea-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    # Arrow + gRPC compile is long-running
+    timeout-minutes: 180
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        platform: ['ubuntu22.04']
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set version
+        id: version
+        run: |
+          echo "BUILD_DATE=$(date -u +'%Y%m%d')" >> $GITHUB_OUTPUT
+          echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Determine if platform changed
+        id: platform-filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            ubuntu22.04:
+              - 'devops/deploy/docker/build/ubuntu22.04/**'
+
+      - name: Set up QEMU
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' || github.event_name == 'workflow_dispatch' }}
+        uses: docker/setup-qemu-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: ${{ (steps.platform-filter.outputs[matrix.platform] == 'true' || github.event_name == 'workflow_dispatch') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' || github.event_name == 'workflow_dispatch' }}
+        uses: docker/setup-buildx-action@v3
+        with:
+          buildkitd-flags: --debug
+
+      - name: Build and test image
+        if: ${{ steps.platform-filter.outputs[matrix.platform] == 'true' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          IMAGE_TAG="ghcr.io/${{ github.repository_owner }}/tea-build:${{ matrix.platform }}-test"
+
+          docker buildx build \
+            --platform linux/amd64 \
+            --load \
+            -t "${IMAGE_TAG}" \
+            ./devops/deploy/docker/build/${{ matrix.platform }}
+
+          docker run -d \
+            -h cdw \
+            --name tea-build-${{ matrix.platform }}-test \
+            "${IMAGE_TAG}" \
+            bash -c "sleep 30"
+
+          docker exec tea-build-${{ matrix.platform }}-test pytest \
+            --cache-clear \
+            -o cache_dir=/tmp/pytest-cache \
+            --disable-warnings \
+            -p no:warnings \
+            /tests/testinfra/test_tea_build_env.py
+
+          docker rm -f tea-build-${{ matrix.platform }}-test
+
+      - name: Build and Push Docker image
+        if: ${{ (steps.platform-filter.outputs[matrix.platform] == 'true' || github.event_name == 'workflow_dispatch') && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        uses: docker/build-push-action@v6
+        with:
+          context: ./devops/deploy/docker/build/${{ matrix.platform }}
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/tea-build:${{ matrix.platform }}-latest
+            ghcr.io/${{ github.repository_owner }}/tea-build:${{ matrix.platform }}-${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.version.outputs.BUILD_DATE }}
+            org.opencontainers.image.version=${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}
+            org.opencontainers.image.description="Containerized environment for building Tea (Arrow, gRPC, gcc-13). Greenplum and Tea are built in CI."
+            org.opencontainers.image.title="Tea Build Environment"
+
+      - name: Build Summary
+        if: always()
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "#### Pull Request Build" >> $GITHUB_STEP_SUMMARY
+            echo "Validation build: image is built and tested locally but **not pushed**." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "### Build Summary for ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### Build Information" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Platform**: ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Architecture**: amd64" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit SHA**: [\`${{ github.sha }}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build Date**: ${{ steps.version.outputs.BUILD_DATE }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### Docker Images" >> $GITHUB_STEP_SUMMARY
+          echo "- Latest tag: \`ghcr.io/${{ github.repository_owner }}/tea-build:${{ matrix.platform }}-latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "- Version tag: \`ghcr.io/${{ github.repository_owner }}/tea-build:${{ matrix.platform }}-${{ steps.version.outputs.BUILD_DATE }}-${{ steps.version.outputs.SHA_SHORT }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "#### Quick Reference" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
+          echo "docker pull ghcr.io/${{ github.repository_owner }}/tea-build:${{ matrix.platform }}-latest" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/devops/build/ubuntu22.04/Dockerfile
+++ b/devops/build/ubuntu22.04/Dockerfile
@@ -1,0 +1,152 @@
+# --------------------------------------------------------------------
+# Dockerfile for Tea Build Environment (Ubuntu 22.04)
+# --------------------------------------------------------------------
+# Based on the open-gpdb jammy/22.04 build image. Pre-installs Tea
+# compile dependencies (Arrow, gRPC, gcc-13, CMake) but does NOT build
+# Greenplum or Tea itself — those stay in CI workflows so Tea sources
+# can change without rebuilding this image.
+#
+# Key Features:
+# - open-gpdb base (gpadmin, SSH, GPDB build tooling)
+# - gcc-13 / g++-13 and CMake >= 3.25 for Tea
+# - LLVM 15 + clang for Arrow Gandiva
+# - Static Arrow (lithium-tech/arrow with Tea patches) and gRPC under
+#   /home/gpadmin/local
+# - TestInfra tests under /tests
+#
+# Usage:
+#   docker build -t tea-build:ubuntu22.04 .
+#   docker run -h cdw -it tea-build:ubuntu22.04
+#
+# Build Tea inside the image (after installing Greenplum elsewhere):
+#   mkdir -p build && cd build
+#   cmake -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+#     -DGreenplum_ROOT=$Greenplum_ROOT -DCMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH \
+#     -DCMAKE_C_COMPILER=gcc-13 -DCMAKE_CXX_COMPILER=g++-13 \
+#     -DTEA_USE_THREAD_SANITIZER=OFF ..
+#   ninja && ninja hive_metastore_server hive_metastore_client && ninja install
+# --------------------------------------------------------------------
+
+ARG BASE_IMAGE=ghcr.io/open-gpdb/gpdb-env:jammy-latest
+FROM ${BASE_IMAGE}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG CMAKE_VERSION=3.31.11
+ARG ARROW_REPO=https://github.com/lithium-tech/arrow.git
+ARG ARROW_REF=maint-15.0.2-tea
+ARG GRPC_REF=v1.62.3
+ARG PARALLEL=8
+
+USER root
+
+ENV USER=gpadmin \
+    HOME=/home/gpadmin \
+    DEPS_PREFIX=/home/gpadmin/local \
+    Greenplum_ROOT=/opt/greenplum-db-6 \
+    CMAKE_PREFIX_PATH=/home/gpadmin/local \
+    PATH="/opt/greenplum-db-6/bin:/usr/local/bin:${PATH}"
+
+# Packages, CMake, TestInfra — single layer.
+# Arrow Gandiva needs LLVM >= 15 and clang; the base image only ships llvm-14.
+RUN apt-get update -o Acquire::AllowInsecureRepositories=true \
+  && apt-get install -y --no-install-recommends --allow-unauthenticated \
+    clang-15 \
+    libclang-15-dev \
+    libcurl4-openssl-dev \
+    libipc-run-perl \
+    libprotobuf-dev \
+    libtool \
+    libxslt1-dev \
+    llvm-15 \
+    llvm-15-dev \
+    pkg-config \
+    protobuf-compiler \
+    python3-pip \
+    redis-server \
+    software-properties-common \
+  && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+  && apt-get install -y --no-install-recommends --allow-unauthenticated \
+    gcc-13 \
+    g++-13 \
+  && (systemctl disable --now redis-server || service redis-server stop || true) \
+  && ln -s -f python2.7 /usr/bin/python \
+  && locale-gen "en_US.UTF-8" \
+  && update-locale LC_ALL="en_US.UTF-8" \
+  && echo '/usr/local/lib' > /etc/ld.so.conf.d/local.conf \
+  && ldconfig \
+  && ARCH="$(uname -m)" \
+  && case "${ARCH}" in \
+       x86_64) CMAKE_ARCH=x86_64 ;; \
+       aarch64) CMAKE_ARCH=aarch64 ;; \
+       *) echo "Unsupported arch: ${ARCH}" >&2; exit 1 ;; \
+     esac \
+  && curl -fsSL \
+       "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-${CMAKE_ARCH}.tar.gz" \
+     | tar -xz -C /usr/local --strip-components=1 \
+  && pip3 install --no-cache-dir pytest-testinfra paramiko \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY tests /tests
+
+USER gpadmin
+WORKDIR /home/gpadmin
+
+# Arrow (lithium-tech fork with Tea patches) + gRPC — single layer.
+RUN mkdir -p "${DEPS_PREFIX}" /tmp/src /home/gpadmin/build/arrow-thirdparty \
+  && git clone --depth 1 -b "${ARROW_REF}" "${ARROW_REPO}" /tmp/src/arrow \
+  && cd /tmp/src/arrow \
+  && ./cpp/thirdparty/download_dependencies.sh /tmp/src/arrow-thirdparty \
+  && cp /tmp/src/arrow-thirdparty/* /home/gpadmin/build/arrow-thirdparty \
+  && mkdir cpp/build && cd cpp/build \
+  && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+       -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+       -DCMAKE_C_COMPILER=gcc-13 \
+       -DCMAKE_CXX_COMPILER=g++-13 \
+       -DLLVM_ROOT=/usr/lib/llvm-15 \
+       -DLLVM_DIR=/usr/lib/llvm-15/lib/cmake/llvm \
+       -DClang_DIR=/usr/lib/llvm-15/lib/cmake/clang \
+       -DCLANG_EXECUTABLE=/usr/bin/clang-15 \
+       -DARROW_BUILD_STATIC=ON \
+       -DARROW_BUILD_SHARED=OFF \
+       -DARROW_DEPENDENCY_SOURCE=BUNDLED \
+       -DARROW_NO_DEPRECATED_API=ON \
+       -DARROW_LLVM_USE_SHARED=OFF \
+       -DARROW_FILESYSTEM=ON \
+       -DARROW_PARQUET=ON \
+       -DARROW_S3=ON \
+       -DARROW_WITH_SNAPPY=ON \
+       -DARROW_WITH_LZ4=ON \
+       -DARROW_WITH_ZLIB=ON \
+       -DARROW_WITH_ZSTD=ON \
+       -DARROW_IPC=ON \
+       -DARROW_CSV=ON \
+       -DARROW_WITH_RAPIDJSON=ON \
+       -DARROW_GANDIVA=ON \
+       -DARROW_COMPUTE=ON \
+       .. \
+  && make -j"${PARALLEL}" && make -j"${PARALLEL}" install \
+  && git clone --depth 1 -b "${GRPC_REF}" https://github.com/grpc/grpc.git /tmp/src/grpc \
+  && cd /tmp/src/grpc \
+  && git submodule update --init --single-branch --depth 1 \
+  && mkdir build && cd build \
+  && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+       -DCMAKE_INSTALL_PREFIX="${DEPS_PREFIX}" \
+       -DCMAKE_C_COMPILER=gcc-13 \
+       -DCMAKE_CXX_COMPILER=g++-13 \
+       -DgRPC_BUILD_SHARED_LIBS=OFF \
+       -DgRPC_BUILD_STATIC_LIBS=ON \
+       -DgRPC_BUILD_TESTS=OFF \
+       -DgRPC_BUILD_EXAMPLES=OFF \
+       -DgRPC_BUILD_CSHARP_EXT=OFF \
+       -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+       -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF \
+       -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+       -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+       -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF \
+       -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
+       -DgRPC_SSL_PROVIDER:STRING=package \
+       .. \
+  && make -j"${PARALLEL}" && make -j"${PARALLEL}" install \
+  && rm -rf /tmp/src
+
+CMD ["bash", "-c", "/tmp/init_system.sh"]

--- a/devops/build/ubuntu22.04/tests/testinfra/test_tea_build_env.py
+++ b/devops/build/ubuntu22.04/tests/testinfra/test_tea_build_env.py
@@ -1,0 +1,84 @@
+# --------------------------------------------------------------------
+# TestInfra checks for the Tea Ubuntu 22.04 build image.
+# --------------------------------------------------------------------
+
+def test_installed_packages(host):
+    packages = [
+        "clang-15",
+        "gcc-13",
+        "g++-13",
+        "git",
+        "libclang-15-dev",
+        "libcurl4-openssl-dev",
+        "libipc-run-perl",
+        "libprotobuf-dev",
+        "libtool",
+        "libxslt1-dev",
+        "llvm-15",
+        "llvm-15-dev",
+        "pkg-config",
+        "protobuf-compiler",
+        "python3-pip",
+        "redis-server",
+    ]
+    for package in packages:
+        assert host.package(package).is_installed
+
+
+def test_user_gpadmin_exists(host):
+    user = host.user("gpadmin")
+    assert user.exists
+    assert "gpadmin" in user.groups or "root" in user.groups
+
+
+def test_cmake_version(host):
+    result = host.run("cmake --version")
+    assert result.rc == 0
+    assert "cmake version 3." in result.stdout
+    # Tea requires CMake >= 3.25
+    version = result.stdout.splitlines()[0].split()[-1]
+    major, minor = (int(x) for x in version.split(".")[:2])
+    assert (major, minor) >= (3, 25)
+
+
+def test_compilers(host):
+    assert host.run("gcc-13 --version").rc == 0
+    assert host.run("g++-13 --version").rc == 0
+    assert host.file("/usr/bin/clang-15").exists
+
+
+def test_deps_prefix(host):
+    deps = host.file("/home/gpadmin/local")
+    assert deps.exists
+    assert deps.is_directory
+    assert host.file("/home/gpadmin/local/lib").exists
+    assert host.file("/home/gpadmin/local/include").exists
+
+
+def test_arrow_installed(host):
+    assert host.file("/home/gpadmin/local/include/arrow/api.h").exists
+    assert host.run(
+        "test -n \"$(find /home/gpadmin/local -name '*arrow*' | head -n 1)\""
+    ).rc == 0
+
+
+def test_grpc_installed(host):
+    assert host.file("/home/gpadmin/local/include/grpc/grpc.h").exists
+
+
+def test_environment_variables(host):
+    env = host.environment()
+    assert env.get("DEPS_PREFIX") == "/home/gpadmin/local"
+    assert env.get("CMAKE_PREFIX_PATH") == "/home/gpadmin/local"
+    assert env.get("Greenplum_ROOT") == "/opt/greenplum-db-6"
+
+
+def test_init_system_script(host):
+    script = host.file("/tmp/init_system.sh")
+    assert script.exists
+    assert script.mode == 0o755 or script.mode == 0o777
+
+
+def test_locale_generated(host):
+    locale = host.run("locale -a | grep -i '^en_US\\.utf8$'")
+    assert locale.rc == 0


### PR DESCRIPTION
The same approach as in Cloudberry https://github.com/apache/cloudberry/blob/main/.github/workflows/README.md

1. Take base open-gpdb image
2. Add to image specific tea packages
3. Compile arrow and grpc
4. Install binaries

The resulting data is placed under `/home/gpadmin/local/lib` and `/home/gpadmin/build/arrow-thirdparty` catalogs.

Once it merged we could create new docker image and use it for development/test purposes