### PR TITLE
Don't call GetConfig when Config can be got as a function argument

### DIFF
--- a/tea/gpext/tea.c
+++ b/tea/gpext/tea.c
@@ -8,7 +8,6 @@
 
 #include "tea/gpext/tea_reader.h"
 
-static bool reader_initialized = false;
 static List* readers = NULL;
 
 PG_MODULE_MAGIC;
@@ -48,11 +47,11 @@ static void OnExitCallback(int code, Datum arg) {
 }
 
 TeaContextPtr TeaContextCreate(const char* url) {
-  if (!reader_initialized) {
-    TeaContextInitialize(GetDatabaseEncoding());
+  static bool callbacks_set = false;
+  if (!callbacks_set) {
     RegisterXactCallback(XactCallbackTea, NULL);
     on_shmem_exit(OnExitCallback, 0);
-    reader_initialized = true;
+    callbacks_set = true;
   }
   TeaContextPtr tea_ctx = TeaContextCreateUntracked(url);
   if (tea_ctx) {

--- a/tea/gpext/tea_reader.cpp
+++ b/tea/gpext/tea_reader.cpp
@@ -89,6 +89,62 @@ extern "C" {
 #include "utils/builtins.h"
 }
 
+#define TEA_RETURN_ARROW_NOT_OK(status_or_value_expr)                                  \
+  do {                                                                                 \
+    if (const auto& status_or_value = (status_or_value_expr); !status_or_value.ok()) { \
+      tea::SetArrowError(status_or_value);                                             \
+      return;                                                                          \
+    }                                                                                  \
+  } while (0)
+
+#define TEA_INVOKE(log_level, fn)                             \
+  do {                                                        \
+    tea::is_call_successful = true;                           \
+    tea::Invoke(fn);                                          \
+    tea::PrintLogs();                                         \
+    if (!tea::is_call_successful) {                           \
+      elog((log_level), "Tea error: %s", tea::error_message); \
+    }                                                         \
+  } while (0)
+
+#define TEA_INVOKE_WO_PRINT_LOGS(log_level, fn)               \
+  do {                                                        \
+    tea::is_call_successful = true;                           \
+    tea::Invoke(fn);                                          \
+    if (!tea::is_call_successful) {                           \
+      elog((log_level), "Tea error: %s", tea::error_message); \
+    }                                                         \
+  } while (0)
+
+#define TEA_INVOKE_IN_HELPER_THREAD(log_level, fn)            \
+  do {                                                        \
+    tea::is_call_successful = true;                           \
+    if (tea::thread_pool) {                                   \
+      tea::thread_pool->Invoke([&]() { tea::Invoke(fn); });   \
+    } else {                                                  \
+      tea::Invoke(fn);                                        \
+    }                                                         \
+    tea::PrintLogs();                                         \
+    if (!tea::is_call_successful) {                           \
+      elog((log_level), "Tea error: %s", tea::error_message); \
+    }                                                         \
+  } while (0)
+
+#define TEA_INVOKE_IN_HELPER_THREAD_WITH_INTERRUPTS(log_level, fn)                   \
+  do {                                                                               \
+    tea::is_call_successful = true;                                                  \
+    if (tea::thread_pool) {                                                          \
+      std::future<void> task = tea::thread_pool->Submit([&]() { tea::Invoke(fn); }); \
+      WaitTaskWithInterrupts(task, get::CancelToken(tea_ctx));                       \
+    } else {                                                                         \
+      tea::Invoke(fn);                                                               \
+    }                                                                                \
+    tea::PrintLogs();                                                                \
+    if (!tea::is_call_successful) {                                                  \
+      elog((log_level), "Tea error: %s", tea::error_message);                        \
+    }                                                                                \
+  } while (0)
+
 namespace tea {
 namespace {
 
@@ -275,64 +331,23 @@ uint64_t CountPositionalDeleteFiles(const iceberg::ice_tea::ScanMetadata& scan_m
   return result;
 }
 
+/**
+ * Initialize shared state of the library.
+ */
+void TeaContextInitialize(const tea::Config& config) {
+  TEA_INVOKE(ERROR, [&config] {
+    tea::InitializeLogger();
+    if (config.features.use_helper_thread) {
+      tea::SignalBlocker signal_blocker;
+      tea::thread_pool = new tea::ThreadPool(1);
+    }
+  });
+  TEA_INVOKE_IN_HELPER_THREAD(ERROR,
+                              [=] { TEA_RETURN_ARROW_NOT_OK(tea::Reader::Initialize(config, GetDatabaseEncoding())); });
+}
+
 }  // namespace
 }  // namespace tea
-
-#define TEA_RETURN_ARROW_NOT_OK(status_or_value_expr)                                  \
-  do {                                                                                 \
-    if (const auto& status_or_value = (status_or_value_expr); !status_or_value.ok()) { \
-      tea::SetArrowError(status_or_value);                                             \
-      return;                                                                          \
-    }                                                                                  \
-  } while (0)
-
-#define TEA_INVOKE(log_level, fn)                             \
-  do {                                                        \
-    tea::is_call_successful = true;                           \
-    tea::Invoke(fn);                                          \
-    tea::PrintLogs();                                         \
-    if (!tea::is_call_successful) {                           \
-      elog((log_level), "Tea error: %s", tea::error_message); \
-    }                                                         \
-  } while (0)
-
-#define TEA_INVOKE_WO_PRINT_LOGS(log_level, fn)               \
-  do {                                                        \
-    tea::is_call_successful = true;                           \
-    tea::Invoke(fn);                                          \
-    if (!tea::is_call_successful) {                           \
-      elog((log_level), "Tea error: %s", tea::error_message); \
-    }                                                         \
-  } while (0)
-
-#define TEA_INVOKE_IN_HELPER_THREAD(log_level, fn)            \
-  do {                                                        \
-    tea::is_call_successful = true;                           \
-    if (tea::thread_pool) {                                   \
-      tea::thread_pool->Invoke([&]() { tea::Invoke(fn); });   \
-    } else {                                                  \
-      tea::Invoke(fn);                                        \
-    }                                                         \
-    tea::PrintLogs();                                         \
-    if (!tea::is_call_successful) {                           \
-      elog((log_level), "Tea error: %s", tea::error_message); \
-    }                                                         \
-  } while (0)
-
-#define TEA_INVOKE_IN_HELPER_THREAD_WITH_INTERRUPTS(log_level, fn)                   \
-  do {                                                                               \
-    tea::is_call_successful = true;                                                  \
-    if (tea::thread_pool) {                                                          \
-      std::future<void> task = tea::thread_pool->Submit([&]() { tea::Invoke(fn); }); \
-      WaitTaskWithInterrupts(task, get::CancelToken(tea_ctx));                       \
-    } else {                                                                         \
-      tea::Invoke(fn);                                                               \
-    }                                                                                \
-    tea::PrintLogs();                                                                \
-    if (!tea::is_call_successful) {                                                  \
-      elog((log_level), "Tea error: %s", tea::error_message);                        \
-    }                                                                                \
-  } while (0)
 
 namespace get {
 
@@ -473,13 +488,22 @@ static uint32_t GetScanId(const char* session_id) {
 }
 
 TeaContextPtr TeaContextCreateUntracked(const char* url) {
+  tea::InternalContext* internal_ctx;
+  TEA_INVOKE(ERROR, ([&internal_ctx, url] {
+               internal_ctx = new tea::InternalContext();
+               internal_ctx->table_config = tea::ConfigSource::GetTableConfig(url);
+             }));
+
+  static bool context_initialized = false;
+  if (!context_initialized) {
+    tea::TeaContextInitialize(internal_ctx->table_config.config);
+    context_initialized = true;
+  }
+
   TeaContextPtr result = nullptr;
   TEA_INVOKE_IN_HELPER_THREAD(
-      ERROR, ([url, &result]() {
+      ERROR, ([url, &result, internal_ctx]() {
         result = new TeaContext();
-
-        auto internal_ctx = new tea::InternalContext();
-        internal_ctx->table_config = tea::ConfigSource::GetTableConfig(url);
 
         result->ctx = internal_ctx;
 
@@ -546,18 +570,6 @@ void TeaContextFinalize() {
     }
     tea::FinalizeLogger();
   });
-}
-
-void TeaContextInitialize(int db_encoding) {
-  TEA_INVOKE(ERROR, [] {
-    tea::InitializeLogger();
-    auto config = tea::ConfigSource::GetConfig();
-    if (config.features.use_helper_thread) {
-      tea::SignalBlocker signal_blocker;
-      tea::thread_pool = new tea::ThreadPool(1);
-    }
-  });
-  TEA_INVOKE_IN_HELPER_THREAD(ERROR, [=] { TEA_RETURN_ARROW_NOT_OK(tea::Reader::Initialize(db_encoding)); });
 }
 
 static tea::TableType TableTypeFromSource(const tea::TableSource& source) {

--- a/tea/gpext/tea_reader.h
+++ b/tea/gpext/tea_reader.h
@@ -64,11 +64,6 @@ typedef struct ReaderOptions {
 } ReaderOptions;
 
 /**
- * Initialize shared state of the library.
- */
-void TeaContextInitialize(int db_encoding);
-
-/**
  * Finalize shared state.
  */
 void TeaContextFinalize();

--- a/tea/reader.cpp
+++ b/tea/reader.cpp
@@ -241,12 +241,10 @@ static arrow::Status EnsureThreadsCreated(arrow::internal::ThreadPool* pool) {
   return arrow::Status::OK();
 }
 
-arrow::Status Reader::Initialize(int db_encoding) {
+arrow::Status Reader::Initialize(const Config& config, int db_encoding) {
   SignalBlocker blocker;
 
   InitializeSharedState();
-
-  Config config = ConfigSource::GetConfig();
 
   // Max threads for CPU-bound tasks.
   if (auto max_threads = config.limits.max_cpu_threads) {
@@ -264,7 +262,7 @@ arrow::Status Reader::Initialize(int db_encoding) {
   RETURN_FL_NOT_OK(
       EnsureThreadsCreated(static_cast<arrow::internal::ThreadPool*>(arrow::io::default_io_context().executor())));
 
-  if (auto status = GetSharedState()->InitializeConverter(db_encoding); !status.ok()) {
+  if (auto status = GetSharedState()->InitializeConverter(config, db_encoding); !status.ok()) {
     return status;
   }
 

--- a/tea/reader.h
+++ b/tea/reader.h
@@ -44,7 +44,7 @@ class Reader {
 
   static arrow::Status Finalize();
 
-  static arrow::Status Initialize(int db_encoding);
+  static arrow::Status Initialize(const Config& config, int db_encoding);
 
  public:
   arrow::Result<std::optional<iceberg::BatchWithSelectionVector>> GetNextBatch();

--- a/tea/table/shared_state.cpp
+++ b/tea/table/shared_state.cpp
@@ -18,8 +18,8 @@
 
 namespace tea {
 
-arrow::Status SharedState::InitializeConverter(int db_encoding) {
-  if (!ConfigSource::GetConfig().features.substitute_illegal_code_points) {
+arrow::Status SharedState::InitializeConverter(const Config& config, int db_encoding) {
+  if (!config.features.substitute_illegal_code_points) {
     return arrow::Status::OK();
   }
   auto enc = InitializeIconv(db_encoding);

--- a/tea/table/shared_state.h
+++ b/tea/table/shared_state.h
@@ -4,13 +4,14 @@
 
 #include "arrow/status.h"
 
+#include "tea/common/config.h"
 #include "tea/table/bridge.h"
 
 namespace tea {
 
 class SharedState {
  public:
-  arrow::Status InitializeConverter(int db_encoding);
+  arrow::Status InitializeConverter(const Config& config, int db_encoding);
   arrow::Status FinalizeConverter();
   CharsetConverter GetCharsetConverter(struct FmgrInfo* proc);
 


### PR DESCRIPTION
GetConfig was called from SharedState::InitializeConverter which is called from
Reader::Initialize only. Now Config is passed to
SharedState::InitializeConverter from Reader::Initialize.

GetConfig was called from the Reader::Initialize method which was called from
TeaContextInitialize only. Now Config is passed to Reader::Initialize from
TeaContextInitialize.

TeaContextInitialize was called from TeaContextCreate. Now TeaContextInitialize
is called from TeaContextCreateUntracked, so Config is passed to
TeaContextInitialize from TeaContextCreateUntracked. Algorithm is not changed,
because TeaContextCreateUntracked is called from TeaContextInitialize only.
TeaContextInitialize is removed from the header file, because the function is
called from the same file where it is defined. Move TeaContextInitialize to
anonymous namespace. Move macros before TeaContextInitialize because it uses
them.

Replace the reader_initialized flag with two more local flags.
