### PR TITLE
Add FDW server options support

### DIFF
--- a/tea/common/config.cpp
+++ b/tea/common/config.cpp
@@ -235,6 +235,17 @@ bool Get(const rapidjson::Value* doc, std::string_view section_prefix, std::stri
   return false;
 }
 
+CatalogConfig::CatalogType StrToCatalogType(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(), tolower);
+  if (s.empty() || s == "hms") return CatalogConfig::CatalogType::kHMS;
+  if (s == "nessie") return CatalogConfig::CatalogType::kNessie;
+#if USE_REST
+  if (s == "rest") return CatalogConfig::CatalogType::kREST;
+#endif
+
+  throw std::runtime_error("Catalog type '" + s + "' is not supported");
+}
+
 bool Get(const rapidjson::Value* doc, std::string_view section_prefix, std::string_view section, const std::string& key,
          CatalogConfig::CatalogType* out) {
   const rapidjson::Value* value = Advance(doc, {std::string(section), key});
@@ -244,23 +255,9 @@ bool Get(const rapidjson::Value* doc, std::string_view section_prefix, std::stri
   if (!value->IsString()) {
     return false;
   }
-  std::string str = value->GetString();
-  std::transform(str.begin(), str.end(), str.begin(), tolower);
-  if (str.empty() || str == "hms") {
-    *out = CatalogConfig::CatalogType::kHMS;
-    return true;
-  } else if (str == "nessie") {
-    *out = CatalogConfig::CatalogType::kNessie;
-    return true;
-  }
-#if USE_REST
-  if (str == "rest") {
-    *out = CatalogConfig::CatalogType::kREST;
-    return true;
-  }
-#endif
 
-  throw std::runtime_error("Catalog type '" + str + "' is not supported");
+  *out = StrToCatalogType(value->GetString());
+  return true;
 }
 
 bool Get(const rapidjson::Value* doc, std::string_view section_prefix, std::string_view section, const std::string& key,
@@ -537,6 +534,27 @@ arrow::Status Load(const rapidjson::Document& document, std::string_view profile
   return arrow::Status::OK();
 }
 
+void LoadFDWServerOptions(Config& config, const std::unordered_map<std::string, std::string>& m_server_options) {
+  auto LoadStr = [&m_server_options](std::string& value, const char* key) {
+    if (auto i = m_server_options.find(key); i != m_server_options.end()) {
+      value = i->second;
+    }
+  };
+
+  // s3
+  LoadStr(config.s3.access_key, "s3_access_key");
+  LoadStr(config.s3.secret_key, "s3_secret_key");
+  LoadStr(config.s3.endpoint_override, "s3_endpoint_override");
+  LoadStr(config.s3.scheme, "s3_scheme");
+
+  // catalog
+  if (auto i = m_server_options.find("catalog_type"); i != m_server_options.end())
+    config.catalog.type = StrToCatalogType(i->second);
+
+  LoadStr(config.catalog.rest_url, "catalog_rest_url");
+  LoadStr(config.catalog.rest_warehouse_id, "catalog_rest_warehouse_id");
+}
+
 }  // namespace
 
 TableId TableId::FromString(std::string_view s) {
@@ -621,34 +639,45 @@ arrow::Status Config::FromJsonFile(const std::string& file_path, const std::opti
   return FromJsonStream(input_config, schema_content, profile);
 }
 
-Config ConfigSource::GetConfig(std::string_view profile) {
-  auto json_config_path = Config::GetJsonFilePath();
-  auto json_schema_config_path = Config::GetJsonSchemaFilePath();
-
-  if (!json_config_path.ok()) {
-    throw json_config_path.status();
-  }
-
+Config ConfigSource::GetConfig(const std::unordered_map<std::string, std::string>& m_server_options,
+                               std::string_view profile) {
+  auto i_read_config_file = m_server_options.find("read_config_file");
+  bool read_config = (i_read_config_file == m_server_options.end() || i_read_config_file->second != "false");
   std::optional<std::string> result_file_schema_path;
-  if (std::filesystem::exists(*json_schema_config_path)) {
-    result_file_schema_path = *json_schema_config_path;
-  } else {
-    result_file_schema_path = std::nullopt;
-  }
+  std::string json_config_path;
+  if (read_config) {
+    auto maybe_json_config_path = Config::GetJsonFilePath();
+    auto json_schema_config_path = Config::GetJsonSchemaFilePath();
 
-  if (!std::filesystem::exists(*json_config_path)) {
-    throw arrow::Status::ExecutionError("Cannot load configuration file ", *json_config_path);
+    if (!maybe_json_config_path.ok()) {
+      throw maybe_json_config_path.status();
+    }
+
+    if (std::filesystem::exists(*json_schema_config_path)) {
+      result_file_schema_path = *json_schema_config_path;
+    } else {
+      result_file_schema_path = std::nullopt;
+    }
+
+    json_config_path = *maybe_json_config_path;
+    if (!std::filesystem::exists(json_config_path)) {
+      throw arrow::Status::ExecutionError("Cannot load configuration file ", json_config_path);
+    }
   }
   Config config;
   LoadEnvDefaults(&config);
-  if (auto status = config.FromJsonFile(*json_config_path, result_file_schema_path, profile); !status.ok()) {
-    TEA_LOG("Incorrect json config " + status.message());
-    throw arrow::Status::ExecutionError("Incorrect configuration file ", *json_config_path);
+  if (read_config) {
+    if (auto status = config.FromJsonFile(json_config_path, result_file_schema_path, profile); !status.ok()) {
+      TEA_LOG("Incorrect json config " + status.message());
+      throw arrow::Status::ExecutionError("Incorrect configuration file ", json_config_path);
+    }
   }
+  LoadFDWServerOptions(config, m_server_options);
   return config;
 }
 
-TableConfig ConfigSource::GetTableConfig(std::string_view url, const std::string& overrided_profile) {
+TableConfig ConfigSource::GetTableConfig(const std::unordered_map<std::string, std::string>& m_server_options,
+                                         std::string_view url, const std::string& overrided_profile) {
   if (!url.starts_with(kTeaSchema)) {
     throw arrow::Status::ExecutionError("Url must start with ", kTeaSchema, " but ", url, " found");
   }
@@ -668,7 +697,7 @@ TableConfig ConfigSource::GetTableConfig(std::string_view url, const std::string
   SnapshotRef snapshot_ref = maybe_snapshot_ref.ValueUnsafe();
 
   TableConfig table_config;
-  table_config.config = GetConfig(profile);
+  table_config.config = GetConfig(m_server_options, profile);
   table_config.snapshot_ref = snapshot_ref;
 
   const auto schema =

--- a/tea/common/config.cpp
+++ b/tea/common/config.cpp
@@ -551,8 +551,10 @@ void LoadFDWServerOptions(Config& config, const std::unordered_map<std::string, 
   if (auto i = m_server_options.find("catalog_type"); i != m_server_options.end())
     config.catalog.type = StrToCatalogType(i->second);
 
+#if USE_REST
   LoadStr(config.catalog.rest_url, "catalog_rest_url");
   LoadStr(config.catalog.rest_warehouse_id, "catalog_rest_warehouse_id");
+#endif
 }
 
 }  // namespace

--- a/tea/common/config.h
+++ b/tea/common/config.h
@@ -290,8 +290,10 @@ struct TableConfig {
 
 class ConfigSource {
  public:
-  static Config GetConfig(std::string_view profile = std::string_view());
-  static TableConfig GetTableConfig(std::string_view url, const std::string& overrided_profile = "");
+  static Config GetConfig(const std::unordered_map<std::string, std::string>& m_server_options,
+                          std::string_view profile = std::string_view());
+  static TableConfig GetTableConfig(const std::unordered_map<std::string, std::string>& m_server_options,
+                                    std::string_view url, const std::string& overrided_profile = "");
 };
 
 arrow::Result<std::unordered_map<std::string, std::string>> GetTableToProfileMapping(const std::string& file_content);

--- a/tea/gpext/tea.c
+++ b/tea/gpext/tea.c
@@ -46,14 +46,14 @@ static void OnExitCallback(int code, Datum arg) {
   TeaContextFinalize();
 }
 
-TeaContextPtr TeaContextCreate(const char* url) {
+TeaContextPtr TeaContextCreate(const List* server_options, const char* url) {
   static bool callbacks_set = false;
   if (!callbacks_set) {
     RegisterXactCallback(XactCallbackTea, NULL);
     on_shmem_exit(OnExitCallback, 0);
     callbacks_set = true;
   }
-  TeaContextPtr tea_ctx = TeaContextCreateUntracked(url);
+  TeaContextPtr tea_ctx = TeaContextCreateUntracked(server_options, url);
   if (tea_ctx) {
     MemoryContext oldcontext = MemoryContextSwitchTo(TopMemoryContext);
     readers = lappend(readers, tea_ctx);

--- a/tea/gpext/tea_exttable.c
+++ b/tea/gpext/tea_exttable.c
@@ -193,7 +193,7 @@ static void InitImportContext(Import* context, char* url, TupleDesc tupdesc, str
   context->columns = (int*)palloc0(sizeof(int) * tupdesc->natts);
   context->values = palloc0(sizeof(Datum) * tupdesc->natts);
   context->nulls = palloc0(sizeof(bool) * tupdesc->natts);
-  context->tea_ctx = TeaContextCreate(url);
+  context->tea_ctx = TeaContextCreate(NIL, url);
   TeaContextGetOptions(context->tea_ctx, &context->options);
   context->ncolumns = GetRequiredColumns(desc, context->columns, tupdesc->natts,
                                          context->options.ext_table_filter_walker_for_projection);

--- a/tea/gpext/tea_fdw.c
+++ b/tea/gpext/tea_fdw.c
@@ -294,7 +294,7 @@ static void TeaGetForeignRelSize(PlannerInfo* root, RelOptInfo* baserel, Oid for
 #endif
   fpinfo->location = TeaGetLocation(RelationGetRelid(rel));
 
-  TeaContextPtr reader = TeaContextCreate(fpinfo->location);
+  TeaContextPtr reader = TeaContextCreate(fpinfo->server->options, fpinfo->location);
   ReaderOptions options;
   TeaContextGetOptions(reader, &options);
   fpinfo->postfilter_on_gp = options.postfilter_on_gp;
@@ -700,7 +700,9 @@ static TupleTableSlot* TeaIterateForeignScan(ForeignScanState* node) {
      * Get connection to the foreign server.  Connection manager will
      * establish new connection if necessary.
      */
-    import->tea_ctx = TeaContextCreate(fsstate->location);
+    ForeignTable* ft = GetForeignTable(node->ss.ss_currentRelation->rd_id);
+    ForeignServer* server = GetForeignServer(ft->serverid);
+    import->tea_ctx = TeaContextCreate(server->options, fsstate->location);
     TeaContextGetOptions(import->tea_ctx, &import->options);
     if (import->options.use_custom_heap_form_tuple) {
       InitHeapFormTupleInfo(&import->heap_form_tuple_info, import->columns, import->ncolumns);
@@ -843,7 +845,9 @@ static int TeaAcquireSampleRowsFunc(Relation relation, int elevel, HeapTuple* ro
 
   const char* url = fsstate->location;
 
-  import->tea_ctx = TeaContextCreate(url);
+  ForeignTable* ft = GetForeignTable(RelationGetRelid(relation));
+  ForeignServer* server = GetForeignServer(ft->serverid);
+  import->tea_ctx = TeaContextCreate(server->options, url);
   AnalyzeParams* params = MakeAnalyzeParams(fsstate, url);
 
   TeaContextPlanAnalyze(import->tea_ctx, params);
@@ -967,7 +971,9 @@ static bool TeaAnalyzeForeignTable(Relation relation, AcquireSampleRowsFunc* fun
   GetScanSessionId(session_id, SESSION_ID_LEN);
 
   {
-    TeaContextPtr tea_ctx = TeaContextCreate(url);
+    ForeignTable* ft = GetForeignTable(RelationGetRelid(relation));
+    ForeignServer* server = GetForeignServer(ft->serverid);
+    TeaContextPtr tea_ctx = TeaContextCreate(server->options, url);
     TupleDesc desc = RelationGetDescr(relation);
     int ncolumns = desc->natts;
     bool* is_remote_only = (bool*)palloc0(sizeof(bool) * ncolumns);
@@ -1084,7 +1090,8 @@ Datum tea_fdw_validator(PG_FUNCTION_ARGS) {
 Datum tea_fdw_get_create_query(PG_FUNCTION_ARGS) {
   char* name = text_to_cstring(PG_GETARG_TEXT_P(0));
   char* location = text_to_cstring(PG_GETARG_TEXT_P(1));
-  char* query = TeaFDWGetCreateQuery(name, location);
+  ForeignServer* fs = GetForeignServerByName("tea_server", false);
+  char* query = TeaFDWGetCreateQuery(name, location, fs->options);
   pfree(location);
   pfree(name);
   PG_RETURN_CSTRING(query);

--- a/tea/gpext/tea_reader.cpp
+++ b/tea/gpext/tea_reader.cpp
@@ -84,6 +84,7 @@ extern "C" {
 #include "postgres.h"  // NOLINT build/include_subdir
 
 #include "cdb/cdbvars.h"
+#include "commands/defrem.h"
 #include "mb/pg_wchar.h"
 #include "miscadmin.h"
 #include "utils/builtins.h"
@@ -414,7 +415,8 @@ std::shared_ptr<iceberg::IFileSystemProvider> MakeFileSystemProvider(const tea::
 }
 
 void UpdateConfig(const std::string& profile_to_tables_path, std::shared_ptr<iceberg::IFileSystemProvider> fs_provider,
-                  const std::string& table_url, tea::TableConfig& config) {
+                  const std::unordered_map<std::string, std::string>& m_server_options, const std::string& table_url,
+                  tea::TableConfig& config) {
   arrow::Result<std::string> maybe_file_content = tea::ReadFile(fs_provider, profile_to_tables_path);
   if (!maybe_file_content.ok()) {
     std::string message = "Failed to read profile-to-tables config: " + maybe_file_content.status().message();
@@ -443,7 +445,7 @@ void UpdateConfig(const std::string& profile_to_tables_path, std::shared_ptr<ice
       }();
       if (table_id.has_value() && table_to_profile.contains(*table_id)) {
         TEA_LOG("Profile for table '" + *table_id + "' is overrided as " + table_to_profile.at(*table_id));
-        config = tea::ConfigSource::GetTableConfig(table_url, table_to_profile.at(*table_id));
+        config = tea::ConfigSource::GetTableConfig(m_server_options, table_url, table_to_profile.at(*table_id));
       }
     }
   }
@@ -487,11 +489,17 @@ static uint32_t GetScanId(const char* session_id) {
   return ++scan_identifier;
 }
 
-TeaContextPtr TeaContextCreateUntracked(const char* url) {
+TeaContextPtr TeaContextCreateUntracked(const List* server_options, const char* url) {
   tea::InternalContext* internal_ctx;
-  TEA_INVOKE(ERROR, ([&internal_ctx, url] {
+  std::unordered_map<std::string, std::string> m_server_options;
+  TEA_INVOKE(ERROR, ([&internal_ctx, &m_server_options, server_options, url] {
                internal_ctx = new tea::InternalContext();
-               internal_ctx->table_config = tea::ConfigSource::GetTableConfig(url);
+               ListCell* lc;
+               foreach (lc, server_options) {
+                 DefElem* def = (DefElem*)lfirst(lc);
+                 m_server_options[def->defname] = defGetString(def);
+               }
+               internal_ctx->table_config = tea::ConfigSource::GetTableConfig(m_server_options, url);
              }));
 
   static bool context_initialized = false;
@@ -502,7 +510,7 @@ TeaContextPtr TeaContextCreateUntracked(const char* url) {
 
   TeaContextPtr result = nullptr;
   TEA_INVOKE_IN_HELPER_THREAD(
-      ERROR, ([url, &result, internal_ctx]() {
+      ERROR, ([&m_server_options, url, &result, internal_ctx]() {
         result = new TeaContext();
 
         result->ctx = internal_ctx;
@@ -515,7 +523,8 @@ TeaContextPtr TeaContextCreateUntracked(const char* url) {
 
         const std::string& profile_to_tables_path = internal_ctx->table_config.config.profile_to_tables_path;
         if (!profile_to_tables_path.empty()) {
-          UpdateConfig(profile_to_tables_path, internal_ctx->fs_provider, url, internal_ctx->table_config);
+          UpdateConfig(profile_to_tables_path, internal_ctx->fs_provider, m_server_options, url,
+                       internal_ctx->table_config);
         }
 
         LogSourceType(internal_ctx->table_config.source);
@@ -1397,14 +1406,14 @@ static std::string GetGreenplumTypeName(std::string type) {
   return type;
 }
 
-char* TeaFDWGetCreateQuery(const char* name, const char* location) {
+char* TeaFDWGetCreateQuery(const char* name, const char* location, const List* server_options) {
   using namespace iceberg;
   using namespace json_parse;
 
   char* query;
-  TEA_INVOKE_WO_PRINT_LOGS(ERROR, ([name, location, &query] {
+  TEA_INVOKE_WO_PRINT_LOGS(ERROR, ([name, location, server_options, &query] {
                              // Download JSON
-                             TeaContextPtr tea_ctx = TeaContextCreate(location);
+                             TeaContextPtr tea_ctx = TeaContextCreate(server_options, location);
                              const tea::TableConfig& table_config = get::TableConfig(tea_ctx);
                              std::string table_metadata_location = tea::meta::access::GetIcebergTableLocation(
                                  table_config.config, std::get<tea::IcebergTable>(table_config.source).table_id);

--- a/tea/gpext/tea_reader.h
+++ b/tea/gpext/tea_reader.h
@@ -14,6 +14,8 @@ extern "C" {
 #include "tea/observability/ext_stats.h"
 #include "tea/table/gp_fwd.h"
 
+typedef struct List List;
+
 typedef void* InternalContextPtr;
 
 typedef struct TeaContext {
@@ -71,12 +73,12 @@ void TeaContextFinalize();
 /**
  * Create reader instance.
  */
-TeaContextPtr TeaContextCreate(const char* url);
+TeaContextPtr TeaContextCreate(const List* server_options, const char* url);
 
 /**
  * Create reader instance. Does not to checks for initialization or tracks the instance for automatic deinitialization.
  */
-TeaContextPtr TeaContextCreateUntracked(const char* url);
+TeaContextPtr TeaContextCreateUntracked(const List* server_options, const char* url);
 
 /**
  * Destroy reader instance.
@@ -132,7 +134,7 @@ void TeaContextGetOptions(TeaContextPtr tea_ctx, ReaderOptions* options);
 void TeaContextLogStats(const TeaContextPtr tea_ctx, const char* event);
 
 #ifdef FDW_GET_CREATE_QUERY
-char* TeaFDWGetCreateQuery(const char* name, const char* location);
+char* TeaFDWGetCreateQuery(const char* name, const char* location, const List* server_options);
 #endif
 
 #ifdef __cplusplus

--- a/tea/table/ut/config_test.cpp
+++ b/tea/table/ut/config_test.cpp
@@ -159,14 +159,17 @@ TEST_F(ConfigSourceTest, InvalidUrl) {
 
 TEST(ConfigSourceTestWithoutConfig, ServerOptions) {
   std::unordered_map<std::string, std::string> m_server_options = {
-      {"read_config_file", "false"},
-      {"s3_access_key", "ak"},
-      {"s3_secret_key", "sk"},
-      {"s3_endpoint_override", "storage.yandexcloud.net"},
-      {"s3_scheme", "http"},
-      {"catalog_type", "rest"},
-      {"catalog_rest_url", "http://127.0.0.1:8181/catalog"},
-      {"catalog_rest_warehouse_id", "91dc12d2-534d-11f1-9109-73b91866a831"}};
+    {"read_config_file", "false"},
+    {"s3_access_key", "ak"},
+    {"s3_secret_key", "sk"},
+    {"s3_endpoint_override", "storage.yandexcloud.net"},
+    {"s3_scheme", "http"},
+    {"catalog_type", "nessie"},
+#if USE_REST
+    {"catalog_rest_url", "http://127.0.0.1:8181/catalog"},
+    {"catalog_rest_warehouse_id", "91dc12d2-534d-11f1-9109-73b91866a831"}
+#endif
+  };
 
   TableConfig tc = ConfigSource::GetTableConfig(m_server_options, "tea://iceberg://table.id");
   Config& config = tc.config;
@@ -174,9 +177,11 @@ TEST(ConfigSourceTestWithoutConfig, ServerOptions) {
   EXPECT_EQ(config.s3.secret_key, "sk");
   EXPECT_EQ(config.s3.endpoint_override, "storage.yandexcloud.net");
   EXPECT_EQ(config.s3.scheme, "http");
-  EXPECT_EQ(config.catalog.type, CatalogConfig::CatalogType::kREST);
+  EXPECT_EQ(config.catalog.type, CatalogConfig::CatalogType::kNessie);
+#if USE_REST
   EXPECT_EQ(config.catalog.rest_url, "http://127.0.0.1:8181/catalog");
   EXPECT_EQ(config.catalog.rest_warehouse_id, "91dc12d2-534d-11f1-9109-73b91866a831");
+#endif
 }
 
 }  // namespace

--- a/tea/table/ut/config_test.cpp
+++ b/tea/table/ut/config_test.cpp
@@ -106,52 +106,77 @@ struct ConfigSourceTest : public testing::Test {
 
 TEST_F(ConfigSourceTest, TableTypes) {
   TableConfig config;
+  std::unordered_map<std::string, std::string> m_server_options;
 
-  config = ConfigSource::GetTableConfig("tea://special://empty");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://special://empty");
   EXPECT_TRUE(std::holds_alternative<EmptyTable>(config.source));
 
-  config = ConfigSource::GetTableConfig("tea://file:///root/subdir/file");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://file:///root/subdir/file");
   EXPECT_THAT(config.source, testing::VariantWith<FileTable>(FileTable{"file:///root/subdir/file"}));
 
-  config = ConfigSource::GetTableConfig("tea://s3://bucket/prefix/file");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://s3://bucket/prefix/file");
   EXPECT_THAT(config.source, testing::VariantWith<FileTable>(FileTable{"s3://bucket/prefix/file"}));
 
-  config = ConfigSource::GetTableConfig("tea://teapot://table.id");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://teapot://table.id");
   EXPECT_THAT(config.source, testing::VariantWith<TeapotTable>(TeapotTable{.table_id = {"table", "id"}}));
 
-  config = ConfigSource::GetTableConfig("tea://teapot://host:1234/table.id");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://teapot://host:1234/table.id");
   EXPECT_THAT(config.source, testing::VariantWith<TeapotTable>(TeapotTable{.table_id = {"table", "id"}}));
   EXPECT_EQ(config.config.teapot.location, "host:1234");
 
-  config = ConfigSource::GetTableConfig("tea://table.id");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://table.id");
   EXPECT_THAT(config.source, testing::VariantWith<TeapotTable>(TeapotTable{.table_id = {"table", "id"}}));
 
-  config = ConfigSource::GetTableConfig("tea://table.id?profile=override");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://table.id?profile=override");
   EXPECT_THAT(config.source, testing::VariantWith<TeapotTable>(TeapotTable{.table_id = {"table", "id"}}));
   EXPECT_EQ(config.config.s3.access_key, "OVERRIDE");
 
-  config = ConfigSource::GetTableConfig("tea://iceberg://table.id");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://iceberg://table.id");
   EXPECT_THAT(config.source, testing::VariantWith<IcebergTable>(IcebergTable{.table_id = {"table", "id"}}));
 
-  config = ConfigSource::GetTableConfig("tea://iceberg://table.id?snapshot_id=123");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://iceberg://table.id?snapshot_id=123");
   EXPECT_THAT(config.source, testing::VariantWith<IcebergTable>(IcebergTable{.table_id = {"table", "id"}}));
   ASSERT_TRUE(std::holds_alternative<Snapshot>(config.snapshot_ref));
   EXPECT_EQ(std::get<Snapshot>(config.snapshot_ref).snapshot_id, 123);
 
-  config = ConfigSource::GetTableConfig("tea://iceberg://table.id?branch=test-branch");
+  config = ConfigSource::GetTableConfig(m_server_options, "tea://iceberg://table.id?branch=test-branch");
   EXPECT_THAT(config.source, testing::VariantWith<IcebergTable>(IcebergTable{.table_id = {"table", "id"}}));
   ASSERT_TRUE(std::holds_alternative<Branch>(config.snapshot_ref));
   EXPECT_EQ(std::get<Branch>(config.snapshot_ref).name, "test-branch");
 }
 
 TEST_F(ConfigSourceTest, InvalidUrl) {
-  EXPECT_ANY_THROW(ConfigSource::GetTableConfig("special://empty"));
-  EXPECT_ANY_THROW(ConfigSource::GetTableConfig("tea://special://unrecognized_special"));
-  EXPECT_ANY_THROW(ConfigSource::GetTableConfig("tea://hdfs://unsupported"));
-  EXPECT_ANY_THROW(ConfigSource::GetTableConfig("tea://teapot://invalid_table_id"));
-  EXPECT_ANY_THROW(ConfigSource::GetTableConfig("tea://iceberg://invalid_table_id"));
-  EXPECT_ANY_THROW(ConfigSource::GetTableConfig("tea://iceberg://table.id?snapshot_id=abc"));
-  EXPECT_ANY_THROW(ConfigSource::GetTableConfig("tea://iceberg://table.id?snapshot_id=123&branch=test-branch"));
+  std::unordered_map<std::string, std::string> m_server_options;
+  EXPECT_ANY_THROW(ConfigSource::GetTableConfig(m_server_options, "special://empty"));
+  EXPECT_ANY_THROW(ConfigSource::GetTableConfig(m_server_options, "tea://special://unrecognized_special"));
+  EXPECT_ANY_THROW(ConfigSource::GetTableConfig(m_server_options, "tea://hdfs://unsupported"));
+  EXPECT_ANY_THROW(ConfigSource::GetTableConfig(m_server_options, "tea://teapot://invalid_table_id"));
+  EXPECT_ANY_THROW(ConfigSource::GetTableConfig(m_server_options, "tea://iceberg://invalid_table_id"));
+  EXPECT_ANY_THROW(ConfigSource::GetTableConfig(m_server_options, "tea://iceberg://table.id?snapshot_id=abc"));
+  EXPECT_ANY_THROW(
+      ConfigSource::GetTableConfig(m_server_options, "tea://iceberg://table.id?snapshot_id=123&branch=test-branch"));
+}
+
+TEST(ConfigSourceTestWithoutConfig, ServerOptions) {
+  std::unordered_map<std::string, std::string> m_server_options = {
+      {"read_config_file", "false"},
+      {"s3_access_key", "ak"},
+      {"s3_secret_key", "sk"},
+      {"s3_endpoint_override", "storage.yandexcloud.net"},
+      {"s3_scheme", "http"},
+      {"catalog_type", "rest"},
+      {"catalog_rest_url", "http://127.0.0.1:8181/catalog"},
+      {"catalog_rest_warehouse_id", "91dc12d2-534d-11f1-9109-73b91866a831"}};
+
+  TableConfig tc = ConfigSource::GetTableConfig(m_server_options, "tea://iceberg://table.id");
+  Config& config = tc.config;
+  EXPECT_EQ(config.s3.access_key, "ak");
+  EXPECT_EQ(config.s3.secret_key, "sk");
+  EXPECT_EQ(config.s3.endpoint_override, "storage.yandexcloud.net");
+  EXPECT_EQ(config.s3.scheme, "http");
+  EXPECT_EQ(config.catalog.type, CatalogConfig::CatalogType::kREST);
+  EXPECT_EQ(config.catalog.rest_url, "http://127.0.0.1:8181/catalog");
+  EXPECT_EQ(config.catalog.rest_warehouse_id, "91dc12d2-534d-11f1-9109-73b91866a831");
 }
 
 }  // namespace


### PR DESCRIPTION
Add possibility to configure TEA using SQL and don't use tea-config.json.
Settings can be got from FDW server options. When there is no 
read_config_file=false in FDW server options, setting are read from
tea-config.json.
Not all setting are supported now. Other setting will be added in the future.
Add the StrToCatalogType function, because now string casting to CatalogType is
executed in two functions.