### PR TITLE
Remove a redundant inclusion

### DIFF
--- a/tea/common/utils.cpp
+++ b/tea/common/utils.cpp
@@ -23,7 +23,6 @@
 #include "iceberg/type.h"
 
 #include "tea/observability/tea_log.h"
-#include "tea/smoke_test/fragment_info.h"
 #include "teapot/teapot.pb.h"
 
 namespace tea {


### PR DESCRIPTION
Declarations from fragment_info.h are not used in utils.cpp.